### PR TITLE
Remove prettier runtime dependency, use only for tests

### DIFF
--- a/src/LazyMessageReader.test.ts
+++ b/src/LazyMessageReader.test.ts
@@ -1,4 +1,6 @@
 import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
+import parserBabel from "prettier/parser-babel";
+import prettier from "prettier/standalone";
 
 import { LazyMessageReader } from "./LazyMessageReader";
 import messageReaderTests from "./fixtures/messageReaderTests";
@@ -11,7 +13,10 @@ describe("LazyReader", () => {
       const reader = new LazyMessageReader(parseMessageDefinition(msgDef));
 
       // allows for easier review of the generated parser source
-      expect(reader.source()).toMatchSnapshot(msgDef);
+      const source = reader.source();
+      expect(prettier.format(source, { parser: "babel", plugins: [parserBabel] })).toMatchSnapshot(
+        msgDef,
+      );
 
       // read aligned array
       {

--- a/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -7,113 +7,112 @@ exports[`LazyReader should deserialize CustomType custom
     ============
     MSG: custom_type/CustomType
     uint8 first 1`] = `
-"function anonymous(readers,sizes
-) {
-class custom_type_CustomType {
-  static first_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 first
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new custom_type_CustomType(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
-
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
-}
-
-class __RootMsg {
-  static custom_size(view /* dataview */, offset) {
-    return custom_type_CustomType.size(view, offset);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // custom_type/CustomType custom
-    {
-      const size = __RootMsg.custom_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class custom_type_CustomType {
+    static first_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint8 first
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new custom_type_CustomType(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
+
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
   }
 
-  custom_offset(view, initOffset) {
-    return initOffset;
-  }
+  class __RootMsg {
+    static custom_size(view /* dataview */, offset) {
+      return custom_type_CustomType.size(view, offset);
+    }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // custom_type/CustomType custom
+      {
+        const size = __RootMsg.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      return totalSize;
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      custom: this.custom.toJSON(),
-    };
-  }
+    custom_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  get custom() {
-    const offset = this.custom_offset(this.#view, this.#offset);
-    return custom_type_CustomType.build(this.#view, offset);
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        custom: this.custom.toJSON(),
+      };
+    }
+
+    get custom() {
+      const offset = this.custom_offset(this.#view, this.#offset);
+      return custom_type_CustomType.build(this.#view, offset);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize CustomType[] custom
@@ -129,172 +128,171 @@ exports[`LazyReader should deserialize CustomType[] custom
     ============
     MSG: custom_type/MoreCustom
     uint8 field 1`] = `
-"function anonymous(readers,sizes
-) {
-class custom_type_MoreCustom {
-  static field_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 field
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  field_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of custom_type_MoreCustom from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new custom_type_MoreCustom(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      field: this.field,
-    };
-  }
-
-  get field() {
-    const offset = this.field_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
-}
-
-class custom_type_CustomType {
-  static another_size(view /* dataview */, offset) {
-    return custom_type_MoreCustom.size(view, offset);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // custom_type/MoreCustom another
-    {
-      const size = custom_type_CustomType.another_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class custom_type_MoreCustom {
+    static field_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  another_offset(view, initOffset) {
-    return initOffset;
-  }
+      // uint8 field
+      totalSize += 1;
+      offset += 1;
 
-  // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new custom_type_CustomType(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      another: this.another.toJSON(),
-    };
-  }
-
-  get another() {
-    const offset = this.another_offset(this.#view, this.#offset);
-    return custom_type_MoreCustom.build(this.#view, offset);
-  }
-}
-
-class __RootMsg {
-  static custom_size(view /* dataview */, offset) {
-    return sizes.array(view, offset, custom_type_CustomType.size);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // custom_type/CustomType custom
-    {
-      const size = __RootMsg.custom_size(view, offset);
-      totalSize += size;
-      offset += size;
+      return totalSize;
     }
 
-    return totalSize;
+    field_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of custom_type_MoreCustom from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new custom_type_MoreCustom(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        field: this.field,
+      };
+    }
+
+    get field() {
+      const offset = this.field_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
   }
 
-  custom_offset(view, initOffset) {
-    return initOffset;
+  class custom_type_CustomType {
+    static another_size(view /* dataview */, offset) {
+      return custom_type_MoreCustom.size(view, offset);
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // custom_type/MoreCustom another
+      {
+        const size = custom_type_CustomType.another_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
+
+      return totalSize;
+    }
+
+    another_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new custom_type_CustomType(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        another: this.another.toJSON(),
+      };
+    }
+
+    get another() {
+      const offset = this.another_offset(this.#view, this.#offset);
+      return custom_type_MoreCustom.build(this.#view, offset);
+    }
   }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+  class __RootMsg {
+    static custom_size(view /* dataview */, offset) {
+      return sizes.array(view, offset, custom_type_CustomType.size);
+    }
 
-  #view = undefined;
-  #offset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      // custom_type/CustomType custom
+      {
+        const size = __RootMsg.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      custom: this.custom.map((item) => item.toJSON()),
-    };
-  }
+      return totalSize;
+    }
 
-  // custom_type/CustomType[] custom
-  get custom() {
-    const offset = this.custom_offset(this.#view, this.#offset);
-    return readers.dynamicArray(
-      this.#view,
-      offset,
-      custom_type_CustomType.build,
-      custom_type_CustomType.size
-    );
+    custom_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        custom: this.custom.map((item) => item.toJSON()),
+      };
+    }
+
+    // custom_type/CustomType[] custom
+    get custom() {
+      const offset = this.custom_offset(this.#view, this.#offset);
+      return readers.dynamicArray(
+        this.#view,
+        offset,
+        custom_type_CustomType.build,
+        custom_type_CustomType.size
+      );
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize CustomType[] custom
@@ -304,119 +302,118 @@ exports[`LazyReader should deserialize CustomType[] custom
     ============
     MSG: custom_type/CustomType
     uint8 first 1`] = `
-"function anonymous(readers,sizes
-) {
-class custom_type_CustomType {
-  static first_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 first
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new custom_type_CustomType(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
-
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
-}
-
-class __RootMsg {
-  static custom_size(view /* dataview */, offset) {
-    return sizes.array(view, offset, custom_type_CustomType.size);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // custom_type/CustomType custom
-    {
-      const size = __RootMsg.custom_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class custom_type_CustomType {
+    static first_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint8 first
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new custom_type_CustomType(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
+
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
   }
 
-  custom_offset(view, initOffset) {
-    return initOffset;
-  }
+  class __RootMsg {
+    static custom_size(view /* dataview */, offset) {
+      return sizes.array(view, offset, custom_type_CustomType.size);
+    }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // custom_type/CustomType custom
+      {
+        const size = __RootMsg.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      return totalSize;
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      custom: this.custom.map((item) => item.toJSON()),
-    };
-  }
+    custom_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  // custom_type/CustomType[] custom
-  get custom() {
-    const offset = this.custom_offset(this.#view, this.#offset);
-    return readers.dynamicArray(
-      this.#view,
-      offset,
-      custom_type_CustomType.build,
-      custom_type_CustomType.size
-    );
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        custom: this.custom.map((item) => item.toJSON()),
+      };
+    }
+
+    // custom_type/CustomType[] custom
+    get custom() {
+      const offset = this.custom_offset(this.#view, this.#offset);
+      return readers.dynamicArray(
+        this.#view,
+        offset,
+        custom_type_CustomType.build,
+        custom_type_CustomType.size
+      );
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize CustomType[3] custom
@@ -426,629 +423,620 @@ exports[`LazyReader should deserialize CustomType[3] custom
     ============
     MSG: custom_type/CustomType
     uint8 first 1`] = `
-"function anonymous(readers,sizes
-) {
-class custom_type_CustomType {
-  static first_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 first
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new custom_type_CustomType(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
-
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
-}
-
-class __RootMsg {
-  static custom_size(view /* dataview */, offset) {
-    return sizes.fixedArray(view, offset, 3, custom_type_CustomType.size);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // custom_type/CustomType custom
-    {
-      const size = __RootMsg.custom_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class custom_type_CustomType {
+    static first_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint8 first
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of custom_type_CustomType from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new custom_type_CustomType(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
+
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
   }
 
-  custom_offset(view, initOffset) {
-    return initOffset;
-  }
+  class __RootMsg {
+    static custom_size(view /* dataview */, offset) {
+      return sizes.fixedArray(view, offset, 3, custom_type_CustomType.size);
+    }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // custom_type/CustomType custom
+      {
+        const size = __RootMsg.custom_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      return totalSize;
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      custom: this.custom.map((item) => item.toJSON()),
-    };
-  }
+    custom_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  // custom_type/CustomType[3] custom
-  get custom() {
-    const offset = this.custom_offset(this.#view, this.#offset);
-    return readers.fixedArray(
-      this.#view,
-      offset,
-      3,
-      custom_type_CustomType.build,
-      custom_type_CustomType.size
-    );
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        custom: this.custom.map((item) => item.toJSON()),
+      };
+    }
+
+    // custom_type/CustomType[3] custom
+    get custom() {
+      const offset = this.custom_offset(this.#view, this.#offset);
+      return readers.fixedArray(
+        this.#view,
+        offset,
+        3,
+        custom_type_CustomType.build,
+        custom_type_CustomType.size
+      );
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static stamp_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static stamp_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // duration stamp
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    stamp_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        stamp: this.stamp,
+      };
+    }
+
+    get stamp() {
+      const offset = this.stamp_offset(this.#view, this.#offset);
+      return readers.duration(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // duration stamp
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  stamp_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      stamp: this.stamp,
-    };
-  }
-
-  get stamp() {
-    const offset = this.stamp_offset(this.#view, this.#offset);
-    return readers.duration(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 8;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // duration arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 8;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
+      // duration arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // duration[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.durationArray(this.#view, offset + 4, len);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
+
+    // duration[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.durationArray(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    return 8 * 1;
-  }
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      return 8 * 1;
+    }
 
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // duration[1] arr
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
 
     // duration[1] arr
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      return readers.durationArray(this.#view, offset, 1);
+    }
   }
-
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
-
-  // duration[1] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    return readers.durationArray(this.#view, offset, 1);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 4;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 4;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // float32 sample
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.float32(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // float32 sample
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.float32(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 4;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // float32 arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 4;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
+      // float32 arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // float32[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.float32Array(this.#view, offset + 4, len);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
+
+    // float32[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.float32Array(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize float32[] first
 float32[] second: float32[] first
 float32[] second 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 4;
-  }
-
-  static second_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 4;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // float32 first
-    {
-      const size = __RootMsg.first_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 4;
     }
 
-    // float32 second
-    {
-      const size = __RootMsg.second_size(view, offset);
-      totalSize += size;
-      offset += size;
+    static second_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 4;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
+      // float32 first
+      {
+        const size = __RootMsg.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  #_second_offset_cache = undefined;
-  second_offset(view, initOffset) {
-    if (this.#_second_offset_cache) {
-      return this.#_second_offset_cache;
+      // float32 second
+      {
+        const size = __RootMsg.second_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
+
+      return totalSize;
     }
-    const prevOffset = this.first_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
-    this.#_second_offset_cache = totalOffset;
-    return totalOffset;
-  }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  #view = undefined;
-  #offset;
+    #_second_offset_cache = undefined;
+    second_offset(view, initOffset) {
+      if (this.#_second_offset_cache) {
+        return this.#_second_offset_cache;
+      }
+      const prevOffset = this.first_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
+      this.#_second_offset_cache = totalOffset;
+      return totalOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-      second: this.second,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // float32[] first
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.float32Array(this.#view, offset + 4, len);
-  }
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
 
-  // float32[] second
-  get second() {
-    const offset = this.second_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.float32Array(this.#view, offset + 4, len);
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+        second: this.second,
+      };
+    }
+
+    // float32[] first
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.float32Array(this.#view, offset + 4, len);
+    }
+
+    // float32[] second
+    get second() {
+      const offset = this.second_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.float32Array(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    return 4 * 2;
-  }
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      return 4 * 2;
+    }
 
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // float32[2] arr
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
 
     // float32[2] arr
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      return readers.float32Array(this.#view, offset, 2);
+    }
   }
-
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
-
-  // float32[2] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    return readers.float32Array(this.#view, offset, 2);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // float64 sample
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.float64(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // float64 sample
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.float64(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int8 STATUS_ONE = 1
@@ -1056,2167 +1044,2133 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
        int8 status: int8 STATUS_ONE = 1
        int8 STATUS_TWO = 2
        int8 status 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static status_size(view /* dataview */, offset) {
-    return 1;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static status_size(view /* dataview */, offset) {
+      return 1;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int8 status
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    status_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        status: this.status,
+      };
+    }
+
+    get status() {
+      const offset = this.status_offset(this.#view, this.#offset);
+      return readers.int8(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int8 status
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  status_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      status: this.status,
-    };
-  }
-
-  get status() {
-    const offset = this.status_offset(this.#view, this.#offset);
-    return readers.int8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int8 first
 int8 second: int8 first
 int8 second 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  static second_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int8 first
-    totalSize += 1;
-    offset += 1;
-
-    // int8 second
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  #_second_offset_cache = undefined;
-  second_offset(view, initOffset) {
-    if (this.#_second_offset_cache) {
-      return this.#_second_offset_cache;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      return 1;
     }
-    const prevOffset = this.first_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
-    this.#_second_offset_cache = totalOffset;
-    return totalOffset;
-  }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    static second_size(view /* dataview */, offset) {
+      return 1;
+    }
 
-  #view = undefined;
-  #offset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      // int8 first
+      totalSize += 1;
+      offset += 1;
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-      second: this.second,
-    };
-  }
+      // int8 second
+      totalSize += 1;
+      offset += 1;
 
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.int8(this.#view, offset);
+      return totalSize;
+    }
+
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    #_second_offset_cache = undefined;
+    second_offset(view, initOffset) {
+      if (this.#_second_offset_cache) {
+        return this.#_second_offset_cache;
+      }
+      const prevOffset = this.first_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
+      this.#_second_offset_cache = totalOffset;
+      return totalOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+        second: this.second,
+      };
+    }
+
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.int8(this.#view, offset);
+    }
+    get second() {
+      const offset = this.second_offset(this.#view, this.#offset);
+      return readers.int8(this.#view, offset);
+    }
   }
-  get second() {
-    const offset = this.second_offset(this.#view, this.#offset);
-    return readers.int8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int8 sample # highest: int8 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 1;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 1;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int8 sample
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int8(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int8 sample
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 1;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 1;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int8 sample
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int8(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int8 sample
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int8 first
-    {
-      const size = __RootMsg.first_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 1;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
+      // int8 first
+      {
+        const size = __RootMsg.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // int8[] first
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.int8Array(this.#view, offset + 4, len);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
+
+    // int8[] first
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.int8Array(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    return 1 * 4;
-  }
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      return 1 * 4;
+    }
 
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int8[4] first
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
 
     // int8[4] first
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.int8Array(this.#view, offset, 4);
+    }
   }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
-
-  // int8[4] first
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.int8Array(this.#view, offset, 4);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int16 sample # highest: int16 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 2;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 2;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int16 sample
+      totalSize += 2;
+      offset += 2;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int16(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int16 sample
-    totalSize += 2;
-    offset += 2;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int16(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 2;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 2;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int16 sample
+      totalSize += 2;
+      offset += 2;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int16(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int16 sample
-    totalSize += 2;
-    offset += 2;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int16(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int32 sample # highest: int32 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 4;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 4;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int32 sample
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int32(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int32 sample
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int32(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 4;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 4;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int32 sample
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int32(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int32 sample
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int32(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 4;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int32 arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 4;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
+      // int32 arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // int32[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.int32Array(this.#view, offset + 4, len);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
+
+    // int32[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.int32Array(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int64 sample # highest: int64 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int64 sample
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int64(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int64 sample
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int64(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // int64 sample
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.int64(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // int64 sample
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.int64(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize string first
 int8 second: string first
 int8 second 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    return sizes.string(view, offset);
-  }
-
-  static second_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // string first
-    {
-      const size = __RootMsg.first_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      return sizes.string(view, offset);
     }
 
-    // int8 second
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  #_second_offset_cache = undefined;
-  second_offset(view, initOffset) {
-    if (this.#_second_offset_cache) {
-      return this.#_second_offset_cache;
+    static second_size(view /* dataview */, offset) {
+      return 1;
     }
-    const prevOffset = this.first_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
-    this.#_second_offset_cache = totalOffset;
-    return totalOffset;
-  }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // string first
+      {
+        const size = __RootMsg.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      // int8 second
+      totalSize += 1;
+      offset += 1;
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-      second: this.second,
-    };
-  }
+      return totalSize;
+    }
 
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.string(this.#view, offset);
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    #_second_offset_cache = undefined;
+    second_offset(view, initOffset) {
+      if (this.#_second_offset_cache) {
+        return this.#_second_offset_cache;
+      }
+      const prevOffset = this.first_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
+      this.#_second_offset_cache = totalOffset;
+      return totalOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+        second: this.second,
+      };
+    }
+
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.string(this.#view, offset);
+    }
+    get second() {
+      const offset = this.second_offset(this.#view, this.#offset);
+      return readers.int8(this.#view, offset);
+    }
   }
-  get second() {
-    const offset = this.second_offset(this.#view, this.#offset);
-    return readers.int8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize string sample # empty string: string sample # empty string 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return sizes.string(view, offset);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // string sample
-    {
-      const size = __RootMsg.sample_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return sizes.string(view, offset);
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
+      // string sample
+      {
+        const size = __RootMsg.sample_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.string(this.#view, offset);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.string(this.#view, offset);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize string sample # some string: string sample # some string 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return sizes.string(view, offset);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // string sample
-    {
-      const size = __RootMsg.sample_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return sizes.string(view, offset);
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
+      // string sample
+      {
+        const size = __RootMsg.sample_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.string(this.#view, offset);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.string(this.#view, offset);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    return sizes.array(view, offset, sizes.string);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // string first
-    {
-      const size = __RootMsg.first_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      return sizes.array(view, offset, sizes.string);
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
+      // string first
+      {
+        const size = __RootMsg.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // string[] first
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.dynamicArray(
-      this.#view,
-      offset,
-      readers.string,
-      sizes.string
-    );
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
+
+    // string[] first
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.dynamicArray(
+        this.#view,
+        offset,
+        readers.string,
+        sizes.string
+      );
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    return sizes.fixedArray(view, offset, 2, sizes.string);
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // string first
-    {
-      const size = __RootMsg.first_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      return sizes.fixedArray(view, offset, 2, sizes.string);
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
+      // string first
+      {
+        const size = __RootMsg.first_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // string[2] first
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.fixedArray(
-      this.#view,
-      offset,
-      2,
-      readers.string,
-      sizes.string
-    );
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
+
+    // string[2] first
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.fixedArray(
+        this.#view,
+        offset,
+        2,
+        readers.string,
+        sizes.string
+      );
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static stamp_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static stamp_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // time stamp
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    stamp_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        stamp: this.stamp,
+      };
+    }
+
+    get stamp() {
+      const offset = this.stamp_offset(this.#view, this.#offset);
+      return readers.time(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // time stamp
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  stamp_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      stamp: this.stamp,
-    };
-  }
-
-  get stamp() {
-    const offset = this.stamp_offset(this.#view, this.#offset);
-    return readers.time(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 8;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // time arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 8;
     }
 
-    return totalSize;
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
+      // time arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+      return totalSize;
+    }
 
-  #view = undefined;
-  #offset;
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
+    #view = undefined;
+    #offset;
 
-  // time[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.timeArray(this.#view, offset + 4, len);
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
+
+    // time[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.timeArray(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static arr_size(view /* dataview */, offset) {
-    return 8 * 1;
-  }
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static arr_size(view /* dataview */, offset) {
+      return 8 * 1;
+    }
 
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // time[1] arr
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    arr_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        arr: this.arr,
+      };
+    }
 
     // time[1] arr
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      return readers.timeArray(this.#view, offset, 1);
+    }
   }
-
-  arr_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      arr: this.arr,
-    };
-  }
-
-  // time[1] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    return readers.timeArray(this.#view, offset, 1);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8 blank
 float32[] arr: uint8 blank
 float32[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static blank_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 4;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 blank
-    totalSize += 1;
-    offset += 1;
-
-    // float32 arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static blank_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
-  }
-
-  blank_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  #_arr_offset_cache = undefined;
-  arr_offset(view, initOffset) {
-    if (this.#_arr_offset_cache) {
-      return this.#_arr_offset_cache;
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 4;
     }
-    const prevOffset = this.blank_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-    this.#_arr_offset_cache = totalOffset;
-    return totalOffset;
-  }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // uint8 blank
+      totalSize += 1;
+      offset += 1;
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      // float32 arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      blank: this.blank,
-      arr: this.arr,
-    };
-  }
+      return totalSize;
+    }
 
-  get blank() {
-    const offset = this.blank_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
+    blank_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  // float32[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.float32Array(this.#view, offset + 4, len);
+    #_arr_offset_cache = undefined;
+    arr_offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
+      }
+      const prevOffset = this.blank_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
+      return totalOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        blank: this.blank,
+        arr: this.arr,
+      };
+    }
+
+    get blank() {
+      const offset = this.blank_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
+
+    // float32[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.float32Array(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8 blank
 float32[2] arr: uint8 blank
 float32[2] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static blank_size(view /* dataview */, offset) {
-    return 1;
-  }
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static blank_size(view /* dataview */, offset) {
+      return 1;
+    }
 
-  static arr_size(view /* dataview */, offset) {
-    return 4 * 2;
-  }
+    static arr_size(view /* dataview */, offset) {
+      return 4 * 2;
+    }
 
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-    // uint8 blank
-    totalSize += 1;
-    offset += 1;
+      // uint8 blank
+      totalSize += 1;
+      offset += 1;
+
+      // float32[2] arr
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    blank_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    #_arr_offset_cache = undefined;
+    arr_offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
+      }
+      const prevOffset = this.blank_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
+      return totalOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        blank: this.blank,
+        arr: this.arr,
+      };
+    }
+
+    get blank() {
+      const offset = this.blank_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
 
     // float32[2] arr
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  blank_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  #_arr_offset_cache = undefined;
-  arr_offset(view, initOffset) {
-    if (this.#_arr_offset_cache) {
-      return this.#_arr_offset_cache;
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      return readers.float32Array(this.#view, offset, 2);
     }
-    const prevOffset = this.blank_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-    this.#_arr_offset_cache = totalOffset;
-    return totalOffset;
   }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      blank: this.blank,
-      arr: this.arr,
-    };
-  }
-
-  get blank() {
-    const offset = this.blank_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
-
-  // float32[2] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    return readers.float32Array(this.#view, offset, 2);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8 blank
 int32[] arr: uint8 blank
 int32[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static blank_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 4;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 blank
-    totalSize += 1;
-    offset += 1;
-
-    // int32 arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static blank_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
-  }
-
-  blank_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  #_arr_offset_cache = undefined;
-  arr_offset(view, initOffset) {
-    if (this.#_arr_offset_cache) {
-      return this.#_arr_offset_cache;
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 4;
     }
-    const prevOffset = this.blank_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-    this.#_arr_offset_cache = totalOffset;
-    return totalOffset;
-  }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // uint8 blank
+      totalSize += 1;
+      offset += 1;
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      // int32 arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      blank: this.blank,
-      arr: this.arr,
-    };
-  }
+      return totalSize;
+    }
 
-  get blank() {
-    const offset = this.blank_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
+    blank_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  // int32[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.int32Array(this.#view, offset + 4, len);
+    #_arr_offset_cache = undefined;
+    arr_offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
+      }
+      const prevOffset = this.blank_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
+      return totalOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        blank: this.blank,
+        arr: this.arr,
+      };
+    }
+
+    get blank() {
+      const offset = this.blank_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
+
+    // int32[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.int32Array(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8 blank
 time[] arr: uint8 blank
 time[] arr 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static blank_size(view /* dataview */, offset) {
-    return 1;
-  }
-
-  static arr_size(view /* dataview */, offset) {
-    const len = view.getUint32(offset, true);
-    return 4 + len * 8;
-  }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 blank
-    totalSize += 1;
-    offset += 1;
-
-    // time arr
-    {
-      const size = __RootMsg.arr_size(view, offset);
-      totalSize += size;
-      offset += size;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static blank_size(view /* dataview */, offset) {
+      return 1;
     }
 
-    return totalSize;
-  }
-
-  blank_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  #_arr_offset_cache = undefined;
-  arr_offset(view, initOffset) {
-    if (this.#_arr_offset_cache) {
-      return this.#_arr_offset_cache;
+    static arr_size(view /* dataview */, offset) {
+      const len = view.getUint32(offset, true);
+      return 4 + len * 8;
     }
-    const prevOffset = this.blank_offset(view, initOffset);
-    const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-    this.#_arr_offset_cache = totalOffset;
-    return totalOffset;
-  }
 
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
 
-  #view = undefined;
-  #offset;
+      // uint8 blank
+      totalSize += 1;
+      offset += 1;
 
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
+      // time arr
+      {
+        const size = __RootMsg.arr_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
 
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      blank: this.blank,
-      arr: this.arr,
-    };
-  }
+      return totalSize;
+    }
 
-  get blank() {
-    const offset = this.blank_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
+    blank_offset(view, initOffset) {
+      return initOffset;
+    }
 
-  // time[] arr
-  get arr() {
-    const offset = this.arr_offset(this.#view, this.#offset);
-    const len = this.#view.getUint32(offset, true);
-    return readers.timeArray(this.#view, offset + 4, len);
+    #_arr_offset_cache = undefined;
+    arr_offset(view, initOffset) {
+      if (this.#_arr_offset_cache) {
+        return this.#_arr_offset_cache;
+      }
+      const prevOffset = this.blank_offset(view, initOffset);
+      const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
+      this.#_arr_offset_cache = totalOffset;
+      return totalOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        blank: this.blank,
+        arr: this.arr,
+      };
+    }
+
+    get blank() {
+      const offset = this.blank_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
+
+    // time[] arr
+    get arr() {
+      const offset = this.arr_offset(this.#view, this.#offset);
+      const len = this.#view.getUint32(offset, true);
+      return readers.timeArray(this.#view, offset + 4, len);
+    }
   }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 1;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 1;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint8 sample
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 sample
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 1;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 1;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint8 sample
+      totalSize += 1;
+      offset += 1;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint8(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint8 sample
-    totalSize += 1;
-    offset += 1;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint8(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static first_size(view /* dataview */, offset) {
-    return 1 * 4;
-  }
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static first_size(view /* dataview */, offset) {
+      return 1 * 4;
+    }
 
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint8[4] first
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    first_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        first: this.first,
+      };
+    }
 
     // uint8[4] first
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
+    get first() {
+      const offset = this.first_offset(this.#view, this.#offset);
+      return readers.uint8Array(this.#view, offset, 4);
+    }
   }
-
-  first_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      first: this.first,
-    };
-  }
-
-  // uint8[4] first
-  get first() {
-    const offset = this.first_offset(this.#view, this.#offset);
-    return readers.uint8Array(this.#view, offset, 4);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 2;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 2;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint16 sample
+      totalSize += 2;
+      offset += 2;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint16(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint16 sample
-    totalSize += 2;
-    offset += 2;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint16(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 2;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 2;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint16 sample
+      totalSize += 2;
+      offset += 2;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint16(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint16 sample
-    totalSize += 2;
-    offset += 2;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint16(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 4;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 4;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint32 sample
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint32(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint32 sample
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint32(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 4;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 4;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint32 sample
+      totalSize += 4;
+      offset += 4;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint32(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint32 sample
-    totalSize += 4;
-    offset += 4;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint32(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # highest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint64 sample
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint64(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint64 sample
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint64(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;
 
 exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # lowest 1`] = `
-"function anonymous(readers,sizes
-) {
-class __RootMsg {
-  static sample_size(view /* dataview */, offset) {
-    return 8;
+"function anonymous(readers, sizes) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return 8;
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // uint64 sample
+      totalSize += 8;
+      offset += 8;
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      return {
+        sample: this.sample,
+      };
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return readers.uint64(this.#view, offset);
+    }
   }
-
-  // return the total serialized size of the message in the view
-  static size(view /* DataView */, initOffset = 0) {
-    let totalSize = 0;
-    let offset = initOffset;
-
-    // uint64 sample
-    totalSize += 8;
-    offset += 8;
-
-    return totalSize;
-  }
-
-  sample_offset(view, initOffset) {
-    return initOffset;
-  }
-
-  // return an instance of __RootMsg from the view at initOffset bytes into the view
-  // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
-  static build(view /* DataView */, offset = 0) {
-    return new __RootMsg(view, offset);
-  }
-
-  #view = undefined;
-  #offset;
-
-  constructor(view, offset = 0) {
-    this.#view = view;
-    this.#offset = offset;
-  }
-
-  // return a json object of the fields
-  // This fully deserializes all fields of the message into native types
-  // Typed arrays are considered native types and remain as typed arrays
-  toJSON() {
-    return {
-      sample: this.sample,
-    };
-  }
-
-  get sample() {
-    const offset = this.sample_offset(this.#view, this.#offset);
-    return readers.uint64(this.#view, offset);
-  }
+  return __RootMsg;
 }
-return __RootMsg;
-
-}"
+"
 `;

--- a/src/buildReader.ts
+++ b/src/buildReader.ts
@@ -223,17 +223,6 @@ function getterFunction(field: RosMsgField): string {
   }
 }
 
-function format(source: string): string {
-  if (process.env.NODE_ENV !== "production") {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const prettier = require("prettier/standalone") as typeof import("prettier/standalone");
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const parserBabel = require("prettier/parser-babel") as typeof import("prettier/parser-babel");
-    return prettier.format(source, { parser: "babel", plugins: [parserBabel] });
-  }
-  return source;
-}
-
 // Create a SerializedMessageReader
 //
 // The output is a set of classes - one for each custom message type. Only the root message
@@ -351,7 +340,7 @@ export default function buildReader(types: readonly RosMsgDefinition[]): Seriali
 
   // close over our builtin deserializers and builtin size functions
   // eslint-disable-next-line @typescript-eslint/no-implied-eval,no-new-func
-  const wrapFn = new Function("readers", "sizes", format(`${src}\nreturn __RootMsg;`));
+  const wrapFn = new Function("readers", "sizes", `${src}\nreturn __RootMsg;`);
   const rootMsg = wrapFn.call(undefined, deserializers, builtinSizes) as SerializedMessageReader;
   rootMsg.source = () => wrapFn.toString();
   return rootMsg;


### PR DESCRIPTION
Fixes #35. Use prettier only for unit test snapshots, not actually at runtime.