### PR TITLE
Use regular MessageReader in lazy message toJSON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,23 @@ jobs:
       - run: yarn build
       - run: yarn lint:ci
       - run: yarn test
-      - run: yarn bench:benny
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: yarn publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
+  bench:
+    name: bench
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+          registry-url: https://registry.npmjs.org
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn bench:benny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: yarn build
       - run: yarn lint:ci
       - run: yarn test
-      - run: yarn bench
+      - run: yarn bench:benny
 
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The `bench` folder contains benchmarks. Run with:
 
 ```
 yarn bench
+yarn bench:benny
 ```
 
 ## Stay in touch

--- a/bench/benny.ts
+++ b/bench/benny.ts
@@ -1,0 +1,229 @@
+import { parse } from "@foxglove/rosmsg";
+import benny from "benny";
+
+import { LazyMessageReader, MessageReader, MessageWriter } from "../src";
+
+type Testcase = {
+  name: string;
+  msgDef: string;
+  msg: unknown;
+  lastField: (msg: unknown) => void;
+};
+
+async function makeSuite(testCase: Testcase): Promise<void> {
+  const name = testCase.name;
+  const msgDefStr = testCase.msgDef;
+  const messageDefinition = parse(msgDefStr);
+
+  const writer = new MessageWriter(messageDefinition);
+  const msgData = writer.writeMessage(testCase.msg);
+  const lastField = testCase.lastField;
+
+  await benny.suite(
+    `${name} - new reader`,
+
+    benny.add("Reg", () => {
+      new MessageReader(messageDefinition);
+    }),
+
+    benny.add("Lazy", () => {
+      new LazyMessageReader(messageDefinition);
+    }),
+
+    benny.cycle(),
+    benny.complete(),
+  );
+
+  await benny.suite(
+    `${name} - read message`,
+
+    benny.add("Reg", () => {
+      const messageReader = new MessageReader(messageDefinition);
+      return () => {
+        messageReader.readMessage(msgData);
+      };
+    }),
+
+    benny.add("Lazy", () => {
+      const messageReader = new LazyMessageReader(messageDefinition);
+      return () => {
+        messageReader.readMessage(msgData);
+      };
+    }),
+
+    benny.add("Lazy - w/toJSON", () => {
+      const messageReader = new LazyMessageReader(messageDefinition);
+      return () => {
+        const msg = messageReader.readMessage(msgData);
+        msg.toJSON();
+      };
+    }),
+
+    benny.cycle(),
+    benny.complete(),
+  );
+
+  await benny.suite(
+    `${name} - read last field`,
+
+    benny.add("Reg", () => {
+      const messageReader = new MessageReader(messageDefinition);
+      return () => {
+        // for regular message reading the last field can only be accessed once the message is read
+        const msg = messageReader.readMessage(msgData);
+        lastField(msg);
+      };
+    }),
+
+    benny.add("Lazy", () => {
+      const messageReader = new LazyMessageReader(messageDefinition);
+      const msg = messageReader.readMessage(msgData);
+      return () => {
+        lastField(msg);
+      };
+    }),
+
+    benny.cycle(),
+    benny.complete(),
+  );
+
+  console.log("---------------------------------------");
+}
+
+async function main() {
+  await makeSuite({
+    name: "int8 array",
+    lastField: (msg) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      void (msg as any).arr[99999];
+    },
+    msgDef: `int8[] arr`,
+    msg: {
+      arr: new Int8Array(100000).fill(3),
+    },
+  });
+
+  await makeSuite({
+    name: "float32 array",
+    lastField: (msg) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      void (msg as any).arr[99999];
+    },
+    msgDef: `float32[] arr`,
+    msg: {
+      arr: new Float32Array(100000).fill(3),
+    },
+  });
+
+  await makeSuite({
+    name: "std_msgs/Header",
+    lastField: (msg) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      void (msg as any).frame_id;
+    },
+    msgDef: `
+      uint32 seq
+      time stamp
+      string frame_id
+    `,
+    msg: {
+      seq: 0,
+      stamp: { sec: 0, nsec: 0 },
+      frame_id: "frame id",
+    },
+  });
+
+  await makeSuite({
+    name: "sensor_msgs/PointCloud2",
+    lastField: (msg) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      void (msg as any).is_dense;
+    },
+    msgDef: `
+        Header header
+        uint32 height
+        uint32 width
+        PointField[] fields
+        bool    is_bigendian
+        uint32  point_step
+        uint32  row_step
+        uint8[] data
+        bool is_dense
+        ===================
+        MSG: std_msgs/Header
+        uint32 seq
+        time stamp
+        string frame_id
+        ===================
+        MSG: sensor_msgs/PointField
+        string name
+        uint32 offset
+        uint8  datatype
+        uint32 count
+          `,
+    msg: {
+      header: {
+        seq: 0,
+        stamp: { sec: 0, nsec: 0 },
+        frame_id: "frame id",
+      },
+      height: 100,
+      width: 100,
+      fields: [
+        { name: "field 1", offset: 0, datatype: 0, count: 0 },
+        { name: "field 2", offset: 0, datatype: 0, count: 0 },
+        { name: "field 3", offset: 0, datatype: 0, count: 0 },
+        { name: "field 4", offset: 0, datatype: 0, count: 0 },
+      ],
+      is_bigendian: false,
+      point_step: 0,
+      row_step: 0,
+      data: new Uint8Array(1000000).fill(0),
+      is_dense: false,
+    },
+  });
+
+  await makeSuite({
+    name: "diagnostic_msgs/DiagnosticArray",
+    lastField: (msg) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      void (msg as any).status[19].values[19].value;
+    },
+    msgDef: `
+    Header header
+    DiagnosticStatus[] status
+    ======================
+    MSG: std_msgs/Header
+    uint32 seq
+    time stamp
+    string frame_id
+    ================
+    MSG: misc/DiagnosticStatus
+    byte level
+    string name
+    string message
+    string hardware_id
+    KeyValue[] values
+    ================
+    MSG: misc/KeyValue
+    string key
+    string value
+    `,
+    msg: {
+      header: {
+        seq: 0,
+        stamp: { sec: 0, nsec: 0 },
+        frame_id: "frame id",
+      },
+      status: new Array(20).fill({
+        level: 0,
+        name: "some name",
+        message: "some message usually longer",
+        hardware_id: "some hardware id",
+        values: new Array(20).fill({ key: "a key", value: "some value" }),
+      }),
+    },
+  });
+}
+
+void main();

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "lint": "eslint --report-unused-disable-directives --fix .",
     "prepublishOnly": "yarn lint:ci && yarn test",
     "test": "jest",
-    "bench": "ts-node --project tsconfig.cjs.json bench/index.ts"
+    "bench": "ts-node --project tsconfig.cjs.json bench/index.ts",
+    "bench:benny": "ts-node --project tsconfig.cjs.json bench/benny.ts"
   },
   "engines": {
     "node": ">= 14"
@@ -48,27 +49,28 @@
     "@foxglove/rosmsg": "^2.0.0"
   },
   "devDependencies": {
-    "@foxglove/eslint-plugin": "0.14.0",
-    "@foxglove/tsconfig": "^1.1.0",
+    "@foxglove/eslint-plugin": "0.17.1",
+    "@foxglove/tsconfig": "1.1.0",
     "@types/jest": "^27.0.1",
-    "@types/node": "^16.6.1",
+    "@types/node": "^16.9.2",
     "@types/prettier": "2.3.2",
-    "@typescript-eslint/eslint-plugin": "4.29.2",
-    "@typescript-eslint/parser": "4.29.2",
-    "console-table-printer": "^2.10.0",
+    "@typescript-eslint/eslint-plugin": "4.31.1",
+    "@typescript-eslint/parser": "4.31.1",
+    "benny": "3.6.15",
+    "console-table-printer": "2.10.0",
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.3.0",
     "eslint-plugin-es": "4.1.0",
     "eslint-plugin-filenames": "1.3.2",
-    "eslint-plugin-import": "2.24.0",
-    "eslint-plugin-jest": "24.4.0",
-    "eslint-plugin-prettier": "3.4.0",
-    "jest": "27.0.6",
-    "kelonio": "^0.6.0",
-    "percentile": "^1.5.0",
-    "prettier": "2.3.2",
+    "eslint-plugin-import": "2.24.2",
+    "eslint-plugin-jest": "24.4.2",
+    "eslint-plugin-prettier": "4.0.0",
+    "jest": "27.2.0",
+    "kelonio": "0.6.0",
+    "percentile": "1.5.0",
+    "prettier": "2.4.1",
     "ts-jest": "27.0.5",
-    "ts-node": "10.2.0",
-    "typescript": "4.3.5"
+    "ts-node": "10.2.1",
+    "typescript": "4.4.3"
   }
 }

--- a/src/BuiltinDeserialize.ts
+++ b/src/BuiltinDeserialize.ts
@@ -119,14 +119,13 @@ type BuiltinTypes = keyof BuiltinTypeMap & FixedSizeTypes;
 
 type BuiltinReaders = {
   [K in BuiltinTypes]: (view: DataView, offset: number) => BuiltinTypeMap[K];
-} &
-  {
-    [K in BuiltinTypes as `${K}Array`]: (
-      view: DataView,
-      offset: number,
-      len: number,
-    ) => K extends keyof BuiltinArrayTypeMap ? BuiltinArrayTypeMap[K] : BuiltinTypeMap[K][];
-  };
+} & {
+  [K in BuiltinTypes as `${K}Array`]: (
+    view: DataView,
+    offset: number,
+    len: number,
+  ) => K extends keyof BuiltinArrayTypeMap ? BuiltinArrayTypeMap[K] : BuiltinTypeMap[K][];
+};
 
 export const deserializers: BuiltinReaders & {
   string: (view: DataView, offset: number) => string;

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -191,7 +191,7 @@ class StandardTypeReader {
   }
 }
 
-const findTypeByName = (types: RosMsgDefinition[], name = ""): NamedRosMsgDefinition => {
+const findTypeByName = (types: readonly RosMsgDefinition[], name = ""): NamedRosMsgDefinition => {
   let foundName = ""; // track name separately in a non-null variable to appease Flow
   const matches = types.filter((type) => {
     const typeName = type.name ?? "";
@@ -247,7 +247,7 @@ function toTypedArrayType(rosType: string): string | undefined {
   }
 }
 
-const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
+const createParser = (types: readonly RosMsgDefinition[], options: { freeze?: boolean }) => {
   if (types.length === 0) {
     throw new Error(`no types given`);
   }
@@ -313,7 +313,7 @@ const createParser = (types: RosMsgDefinition[], freeze: boolean) => {
         readerLines.push(`this.${def.name} = reader.${def.type}();`);
       }
     });
-    if (freeze) {
+    if (options.freeze === true) {
       readerLines.push("Object.freeze(this);");
     }
     return readerLines.join("\n    ");
@@ -351,8 +351,8 @@ export class MessageReader {
   // takes an object message definition and returns
   // a message reader which can be used to read messages based
   // on the message definition
-  constructor(definitions: RosMsgDefinition[], options: { freeze?: boolean } = {}) {
-    this.reader = createParser(definitions, options.freeze === true);
+  constructor(definitions: readonly RosMsgDefinition[], options: { freeze?: boolean } = {}) {
+    this.reader = createParser(definitions, options);
   }
 
   readMessage<T = unknown>(buffer: Readonly<Uint8Array>): T {

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -133,6 +133,7 @@ class StandardTypeWriter {
     this.textEncoder.encodeInto(value, this.data.subarray(stringOffset + 4));
   }
 
+  // eslint-disable-next-line @foxglove/no-boolean-parameters
   bool(value: boolean): void {
     this.uint8(value ? 1 : 0);
   }

--- a/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -7,7 +7,7 @@ exports[`LazyReader should deserialize CustomType custom
     ============
     MSG: custom_type/CustomType
     uint8 first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class custom_type_CustomType {
     static first_size(view /* dataview */, offset) {
       return 1;
@@ -47,14 +47,18 @@ exports[`LazyReader should deserialize CustomType custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
@@ -100,9 +104,13 @@ exports[`LazyReader should deserialize CustomType custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        custom: this.custom.toJSON(),
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get custom() {
@@ -128,7 +136,7 @@ exports[`LazyReader should deserialize CustomType[] custom
     ============
     MSG: custom_type/MoreCustom
     uint8 field 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class custom_type_MoreCustom {
     static field_size(view /* dataview */, offset) {
       return 1;
@@ -168,14 +176,18 @@ exports[`LazyReader should deserialize CustomType[] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        field: this.field,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get field() {
       const offset = this.field_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
@@ -221,9 +233,13 @@ exports[`LazyReader should deserialize CustomType[] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        another: this.another.toJSON(),
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get another() {
@@ -234,7 +250,7 @@ exports[`LazyReader should deserialize CustomType[] custom
 
   class __RootMsg {
     static custom_size(view /* dataview */, offset) {
-      return sizes.array(view, offset, custom_type_CustomType.size);
+      return builtinSizes.array(view, offset, custom_type_CustomType.size);
     }
 
     // return the total serialized size of the message in the view
@@ -274,15 +290,19 @@ exports[`LazyReader should deserialize CustomType[] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        custom: this.custom.map((item) => item.toJSON()),
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // custom_type/CustomType[] custom
     get custom() {
       const offset = this.custom_offset(this.#view, this.#offset);
-      return readers.dynamicArray(
+      return deserializers.dynamicArray(
         this.#view,
         offset,
         custom_type_CustomType.build,
@@ -302,7 +322,7 @@ exports[`LazyReader should deserialize CustomType[] custom
     ============
     MSG: custom_type/CustomType
     uint8 first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class custom_type_CustomType {
     static first_size(view /* dataview */, offset) {
       return 1;
@@ -342,20 +362,24 @@ exports[`LazyReader should deserialize CustomType[] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
   class __RootMsg {
     static custom_size(view /* dataview */, offset) {
-      return sizes.array(view, offset, custom_type_CustomType.size);
+      return builtinSizes.array(view, offset, custom_type_CustomType.size);
     }
 
     // return the total serialized size of the message in the view
@@ -395,15 +419,19 @@ exports[`LazyReader should deserialize CustomType[] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        custom: this.custom.map((item) => item.toJSON()),
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // custom_type/CustomType[] custom
     get custom() {
       const offset = this.custom_offset(this.#view, this.#offset);
-      return readers.dynamicArray(
+      return deserializers.dynamicArray(
         this.#view,
         offset,
         custom_type_CustomType.build,
@@ -423,7 +451,7 @@ exports[`LazyReader should deserialize CustomType[3] custom
     ============
     MSG: custom_type/CustomType
     uint8 first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class custom_type_CustomType {
     static first_size(view /* dataview */, offset) {
       return 1;
@@ -463,20 +491,29 @@ exports[`LazyReader should deserialize CustomType[3] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
 
   class __RootMsg {
     static custom_size(view /* dataview */, offset) {
-      return sizes.fixedArray(view, offset, 3, custom_type_CustomType.size);
+      return builtinSizes.fixedArray(
+        view,
+        offset,
+        3,
+        custom_type_CustomType.size
+      );
     }
 
     // return the total serialized size of the message in the view
@@ -516,15 +553,19 @@ exports[`LazyReader should deserialize CustomType[3] custom
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        custom: this.custom.map((item) => item.toJSON()),
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // custom_type/CustomType[3] custom
     get custom() {
       const offset = this.custom_offset(this.#view, this.#offset);
-      return readers.fixedArray(
+      return deserializers.fixedArray(
         this.#view,
         offset,
         3,
@@ -539,7 +580,7 @@ exports[`LazyReader should deserialize CustomType[3] custom
 `;
 
 exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static stamp_size(view /* dataview */, offset) {
       return 8;
@@ -579,14 +620,18 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        stamp: this.stamp,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get stamp() {
       const offset = this.stamp_offset(this.#view, this.#offset);
-      return readers.duration(this.#view, offset);
+      return deserializers.duration(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -595,7 +640,7 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
 `;
 
 exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
@@ -639,16 +684,20 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // duration[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.durationArray(this.#view, offset + 4, len);
+      return deserializers.durationArray(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -657,7 +706,7 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
 `;
 
 exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       return 8 * 1;
@@ -697,15 +746,19 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // duration[1] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
-      return readers.durationArray(this.#view, offset, 1);
+      return deserializers.durationArray(this.#view, offset, 1);
     }
   }
   return __RootMsg;
@@ -714,7 +767,7 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
 `;
 
 exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 4;
@@ -754,14 +807,18 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.float32(this.#view, offset);
+      return deserializers.float32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -770,7 +827,7 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
 `;
 
 exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
@@ -814,16 +871,20 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // float32[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.float32Array(this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -834,7 +895,7 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
 exports[`LazyReader should deserialize float32[] first
 float32[] second: float32[] first
 float32[] second 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
@@ -901,24 +962,27 @@ float32[] second 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-        second: this.second,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // float32[] first
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.float32Array(this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
 
     // float32[] second
     get second() {
       const offset = this.second_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.float32Array(this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -927,7 +991,7 @@ float32[] second 1`] = `
 `;
 
 exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       return 4 * 2;
@@ -967,15 +1031,19 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // float32[2] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
-      return readers.float32Array(this.#view, offset, 2);
+      return deserializers.float32Array(this.#view, offset, 2);
     }
   }
   return __RootMsg;
@@ -984,7 +1052,7 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
 `;
 
 exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 8;
@@ -1024,14 +1092,18 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.float64(this.#view, offset);
+      return deserializers.float64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1044,7 +1116,7 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
        int8 status: int8 STATUS_ONE = 1
        int8 STATUS_TWO = 2
        int8 status 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static status_size(view /* dataview */, offset) {
       return 1;
@@ -1084,14 +1156,18 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        status: this.status,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get status() {
       const offset = this.status_offset(this.#view, this.#offset);
-      return readers.int8(this.#view, offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1102,7 +1178,7 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
 exports[`LazyReader should deserialize int8 first
 int8 second: int8 first
 int8 second 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
       return 1;
@@ -1161,19 +1237,22 @@ int8 second 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-        second: this.second,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.int8(this.#view, offset);
+      return deserializers.int8(this.#view, offset);
     }
     get second() {
       const offset = this.second_offset(this.#view, this.#offset);
-      return readers.int8(this.#view, offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1182,7 +1261,7 @@ int8 second 1`] = `
 `;
 
 exports[`LazyReader should deserialize int8 sample # highest: int8 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 1;
@@ -1222,14 +1301,18 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int8(this.#view, offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1238,7 +1321,7 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
 `;
 
 exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 1;
@@ -1278,14 +1361,18 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int8(this.#view, offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1294,7 +1381,7 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
 `;
 
 exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
@@ -1338,16 +1425,20 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // int8[] first
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.int8Array(this.#view, offset + 4, len);
+      return deserializers.int8Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1356,7 +1447,7 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
 `;
 
 exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
       return 1 * 4;
@@ -1396,15 +1487,19 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // int8[4] first
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.int8Array(this.#view, offset, 4);
+      return deserializers.int8Array(this.#view, offset, 4);
     }
   }
   return __RootMsg;
@@ -1413,7 +1508,7 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
 `;
 
 exports[`LazyReader should deserialize int16 sample # highest: int16 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 2;
@@ -1453,14 +1548,18 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int16(this.#view, offset);
+      return deserializers.int16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1469,7 +1568,7 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
 `;
 
 exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 2;
@@ -1509,14 +1608,18 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int16(this.#view, offset);
+      return deserializers.int16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1525,7 +1628,7 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
 `;
 
 exports[`LazyReader should deserialize int32 sample # highest: int32 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 4;
@@ -1565,14 +1668,18 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int32(this.#view, offset);
+      return deserializers.int32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1581,7 +1688,7 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
 `;
 
 exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 4;
@@ -1621,14 +1728,18 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int32(this.#view, offset);
+      return deserializers.int32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1637,7 +1748,7 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
 `;
 
 exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
@@ -1681,16 +1792,20 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // int32[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.int32Array(this.#view, offset + 4, len);
+      return deserializers.int32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1699,7 +1814,7 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
 `;
 
 exports[`LazyReader should deserialize int64 sample # highest: int64 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 8;
@@ -1739,14 +1854,18 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int64(this.#view, offset);
+      return deserializers.int64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1755,7 +1874,7 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
 `;
 
 exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 8;
@@ -1795,14 +1914,18 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.int64(this.#view, offset);
+      return deserializers.int64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1813,10 +1936,10 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
 exports[`LazyReader should deserialize string first
 int8 second: string first
 int8 second 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
-      return sizes.string(view, offset);
+      return builtinSizes.string(view, offset);
     }
 
     static second_size(view /* dataview */, offset) {
@@ -1875,19 +1998,22 @@ int8 second 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-        second: this.second,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.string(this.#view, offset);
+      return deserializers.string(this.#view, offset);
     }
     get second() {
       const offset = this.second_offset(this.#view, this.#offset);
-      return readers.int8(this.#view, offset);
+      return deserializers.int8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1896,10 +2022,10 @@ int8 second 1`] = `
 `;
 
 exports[`LazyReader should deserialize string sample # empty string: string sample # empty string 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
-      return sizes.string(view, offset);
+      return builtinSizes.string(view, offset);
     }
 
     // return the total serialized size of the message in the view
@@ -1939,14 +2065,18 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.string(this.#view, offset);
+      return deserializers.string(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -1955,10 +2085,10 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
 `;
 
 exports[`LazyReader should deserialize string sample # some string: string sample # some string 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
-      return sizes.string(view, offset);
+      return builtinSizes.string(view, offset);
     }
 
     // return the total serialized size of the message in the view
@@ -1998,14 +2128,18 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.string(this.#view, offset);
+      return deserializers.string(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2014,10 +2148,10 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
 `;
 
 exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
-      return sizes.array(view, offset, sizes.string);
+      return builtinSizes.array(view, offset, builtinSizes.string);
     }
 
     // return the total serialized size of the message in the view
@@ -2057,19 +2191,23 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // string[] first
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.dynamicArray(
+      return deserializers.dynamicArray(
         this.#view,
         offset,
-        readers.string,
-        sizes.string
+        deserializers.string,
+        builtinSizes.string
       );
     }
   }
@@ -2079,10 +2217,10 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
 `;
 
 exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
-      return sizes.fixedArray(view, offset, 2, sizes.string);
+      return builtinSizes.fixedArray(view, offset, 2, builtinSizes.string);
     }
 
     // return the total serialized size of the message in the view
@@ -2122,20 +2260,24 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // string[2] first
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.fixedArray(
+      return deserializers.fixedArray(
         this.#view,
         offset,
         2,
-        readers.string,
-        sizes.string
+        deserializers.string,
+        builtinSizes.string
       );
     }
   }
@@ -2145,7 +2287,7 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
 `;
 
 exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static stamp_size(view /* dataview */, offset) {
       return 8;
@@ -2185,14 +2327,18 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        stamp: this.stamp,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get stamp() {
       const offset = this.stamp_offset(this.#view, this.#offset);
-      return readers.time(this.#view, offset);
+      return deserializers.time(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2201,7 +2347,7 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
 `;
 
 exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       const len = view.getUint32(offset, true);
@@ -2245,16 +2391,20 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // time[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.timeArray(this.#view, offset + 4, len);
+      return deserializers.timeArray(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2263,7 +2413,7 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
 `;
 
 exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static arr_size(view /* dataview */, offset) {
       return 8 * 1;
@@ -2303,15 +2453,19 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // time[1] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
-      return readers.timeArray(this.#view, offset, 1);
+      return deserializers.timeArray(this.#view, offset, 1);
     }
   }
   return __RootMsg;
@@ -2322,7 +2476,7 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
 exports[`LazyReader should deserialize uint8 blank
 float32[] arr: uint8 blank
 float32[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static blank_size(view /* dataview */, offset) {
       return 1;
@@ -2385,22 +2539,25 @@ float32[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        blank: this.blank,
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get blank() {
       const offset = this.blank_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
     // float32[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.float32Array(this.#view, offset + 4, len);
+      return deserializers.float32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2411,7 +2568,7 @@ float32[] arr 1`] = `
 exports[`LazyReader should deserialize uint8 blank
 float32[2] arr: uint8 blank
 float32[2] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static blank_size(view /* dataview */, offset) {
       return 1;
@@ -2470,21 +2627,24 @@ float32[2] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        blank: this.blank,
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get blank() {
       const offset = this.blank_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
     // float32[2] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
-      return readers.float32Array(this.#view, offset, 2);
+      return deserializers.float32Array(this.#view, offset, 2);
     }
   }
   return __RootMsg;
@@ -2495,7 +2655,7 @@ float32[2] arr 1`] = `
 exports[`LazyReader should deserialize uint8 blank
 int32[] arr: uint8 blank
 int32[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static blank_size(view /* dataview */, offset) {
       return 1;
@@ -2558,22 +2718,25 @@ int32[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        blank: this.blank,
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get blank() {
       const offset = this.blank_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
     // int32[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.int32Array(this.#view, offset + 4, len);
+      return deserializers.int32Array(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2584,7 +2747,7 @@ int32[] arr 1`] = `
 exports[`LazyReader should deserialize uint8 blank
 time[] arr: uint8 blank
 time[] arr 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static blank_size(view /* dataview */, offset) {
       return 1;
@@ -2647,22 +2810,25 @@ time[] arr 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        blank: this.blank,
-        arr: this.arr,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get blank() {
       const offset = this.blank_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
 
     // time[] arr
     get arr() {
       const offset = this.arr_offset(this.#view, this.#offset);
       const len = this.#view.getUint32(offset, true);
-      return readers.timeArray(this.#view, offset + 4, len);
+      return deserializers.timeArray(this.#view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2671,7 +2837,7 @@ time[] arr 1`] = `
 `;
 
 exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 1;
@@ -2711,14 +2877,18 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2727,7 +2897,7 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
 `;
 
 exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 1;
@@ -2767,14 +2937,18 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint8(this.#view, offset);
+      return deserializers.uint8(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2783,7 +2957,7 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
 `;
 
 exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static first_size(view /* dataview */, offset) {
       return 1 * 4;
@@ -2823,15 +2997,19 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        first: this.first,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     // uint8[4] first
     get first() {
       const offset = this.first_offset(this.#view, this.#offset);
-      return readers.uint8Array(this.#view, offset, 4);
+      return deserializers.uint8Array(this.#view, offset, 4);
     }
   }
   return __RootMsg;
@@ -2840,7 +3018,7 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
 `;
 
 exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 2;
@@ -2880,14 +3058,18 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint16(this.#view, offset);
+      return deserializers.uint16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2896,7 +3078,7 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
 `;
 
 exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 2;
@@ -2936,14 +3118,18 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint16(this.#view, offset);
+      return deserializers.uint16(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -2952,7 +3138,7 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
 `;
 
 exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 4;
@@ -2992,14 +3178,18 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint32(this.#view, offset);
+      return deserializers.uint32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3008,7 +3198,7 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
 `;
 
 exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 4;
@@ -3048,14 +3238,18 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint32(this.#view, offset);
+      return deserializers.uint32(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3064,7 +3258,7 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
 `;
 
 exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # highest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 8;
@@ -3104,14 +3298,18 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint64(this.#view, offset);
+      return deserializers.uint64(this.#view, offset);
     }
   }
   return __RootMsg;
@@ -3120,7 +3318,7 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
 `;
 
 exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # lowest 1`] = `
-"function anonymous(readers, sizes) {
+"function anonymous(deserializers, builtinSizes, fullReader) {
   class __RootMsg {
     static sample_size(view /* dataview */, offset) {
       return 8;
@@ -3160,14 +3358,18 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      return {
-        sample: this.sample,
-      };
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset,
+        view.byteLength
+      );
+      return fullReader.readMessage(buffer);
     }
 
     get sample() {
       const offset = this.sample_offset(this.#view, this.#offset);
-      return readers.uint64(this.#view, offset);
+      return deserializers.uint64(this.#view, offset);
     }
   }
   return __RootMsg;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,40 @@
 # yarn lockfile v1
 
 
+"@arrows/array@^1.4.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@arrows/array/-/array-1.4.1.tgz#a6580a08cee219755ca9a8eb14e956d3c29a5508"
+  integrity sha512-MGYS8xi3c4tTy1ivhrVntFvufoNzje0PchjEz6G/SsWRgUKxL4tKwS6iPdO8vsaJYldagAeWMd5KRD0aX3Q39g==
+  dependencies:
+    "@arrows/composition" "^1.2.2"
+
+"@arrows/composition@^1.0.0", "@arrows/composition@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@arrows/composition/-/composition-1.2.2.tgz#d0a213cac8f8c36c1c75856a1e6ed940c27e9169"
+  integrity sha512-9fh1yHwrx32lundiB3SlZ/VwuStPB4QakPsSLrGJFH6rCXvdrd060ivAZ7/2vlqPnEjBkPRRXOcG1YOu19p2GQ==
+
+"@arrows/dispatch@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@arrows/dispatch/-/dispatch-1.0.3.tgz#c4c06260f89e9dd4ce280df3712980aa2f3de976"
+  integrity sha512-v/HwvrFonitYZM2PmBlAlCqVqxrkIIoiEuy5bQgn0BdfvlL0ooSBzcPzTMrtzY8eYktPyYcHg8fLbSgyybXEqw==
+  dependencies:
+    "@arrows/composition" "^1.2.2"
+
+"@arrows/error@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@arrows/error/-/error-1.0.2.tgz#4e68036f901118ba6f1de88656ef6be49e650414"
+  integrity sha512-yvkiv1ay4Z3+Z6oQsUkedsQm5aFdyPpkBUQs8vejazU/RmANABx6bMMcBPPHI4aW43VPQmXFfBzr/4FExwWTEA==
+
+"@arrows/multimethod@^1.1.6":
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/@arrows/multimethod/-/multimethod-1.1.7.tgz#bc7c26c3aa7703fc967e65da4f00718b1428eb4a"
+  integrity sha512-EjHD3XuGAV4G28rm7mu8k7zQJh/EOizh104/p9i2ofGcnL5mgKONFH/Bq6H3SJjM+WDAlKcR9WBpNhaAKCnH2g==
+  dependencies:
+    "@arrows/array" "^1.4.0"
+    "@arrows/composition" "^1.2.2"
+    "@arrows/error" "^1.0.2"
+    fast-deep-equal "^3.1.1"
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -336,10 +370,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@foxglove/eslint-plugin@0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/eslint-plugin/-/eslint-plugin-0.14.0.tgz#d55b512cb86d98ebd228b44e96949867967130c5"
-  integrity sha512-v+sHf5PwH9245i91nG2CO1zLjF21jsL6rhXwyObvvi29XguNum0+wJiXgem64MD6w/zbsmBx4lBYA2DAKISXAA==
+"@foxglove/eslint-plugin@0.17.1":
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/@foxglove/eslint-plugin/-/eslint-plugin-0.17.1.tgz#f29fbe7bf538f2721535a9c06ec6ec607ad72f71"
+  integrity sha512-/Z32WFj7bBfEIdCh0aXTc5mQbVUcm1KvG586FxCq8k0r0oBUml0bAtLIem9IjE7sUWtabSDJWTFLJpHJhlP+XA==
 
 "@foxglove/rosmsg@^2.0.0":
   version "2.0.0"
@@ -348,7 +382,7 @@
   dependencies:
     md5-typescript "^1.0.5"
 
-"@foxglove/tsconfig@^1.1.0":
+"@foxglove/tsconfig@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@foxglove/tsconfig/-/tsconfig-1.1.0.tgz#48c37fffd6f349c3ee08a60fc62ccf636f3b59a6"
   integrity sha512-qZU4MtXVgPhDBFazSEx7yDEuEg8cPHXFQVhBaUABZkCBdcnEE9sxlgEt0gSikF4fRtY6COGIJPVRflnPJXjJKA==
@@ -383,94 +417,94 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.0.6.tgz#3eb72ea80897495c3d73dd97aab7f26770e2260f"
-  integrity sha512-fMlIBocSHPZ3JxgWiDNW/KPj6s+YRd0hicb33IrmelCcjXo/pXPwvuiKFmZz+XuqI/1u7nbUK10zSsWL/1aegg==
+"@jest/console@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.2.0.tgz#57f702837ec52899be58c3794dce5941c77a8b63"
+  integrity sha512-35z+RqsK2CCgNxn+lWyK8X4KkaDtfL4BggT7oeZ0JffIiAiEYFYPo5B67V50ZubqDS1ehBrdCR2jduFnIrZOYw==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^27.0.6"
-    jest-util "^27.0.6"
+    jest-message-util "^27.2.0"
+    jest-util "^27.2.0"
     slash "^3.0.0"
 
-"@jest/core@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.0.6.tgz#c5f642727a0b3bf0f37c4b46c675372d0978d4a1"
-  integrity sha512-SsYBm3yhqOn5ZLJCtccaBcvD/ccTLCeuDv8U41WJH/V1MW5eKUkeMHT9U+Pw/v1m1AIWlnIW/eM2XzQr0rEmow==
+"@jest/core@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.2.0.tgz#61fc27b244e9709170ed9ffe41b006add569f1b3"
+  integrity sha512-E/2NHhq+VMo18DpKkoty8Sjey8Kps5Cqa88A8NP757s6JjYqPdioMuyUBhDiIOGCdQByEp0ou3jskkTszMS0nw==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/reporters" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^27.2.0"
+    "@jest/reporters" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.8.1"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
-    jest-changed-files "^27.0.6"
-    jest-config "^27.0.6"
-    jest-haste-map "^27.0.6"
-    jest-message-util "^27.0.6"
+    jest-changed-files "^27.1.1"
+    jest-config "^27.2.0"
+    jest-haste-map "^27.2.0"
+    jest-message-util "^27.2.0"
     jest-regex-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-resolve-dependencies "^27.0.6"
-    jest-runner "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
-    jest-watcher "^27.0.6"
+    jest-resolve "^27.2.0"
+    jest-resolve-dependencies "^27.2.0"
+    jest-runner "^27.2.0"
+    jest-runtime "^27.2.0"
+    jest-snapshot "^27.2.0"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
+    jest-watcher "^27.2.0"
     micromatch "^4.0.4"
     p-each-series "^2.1.0"
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.0.6.tgz#ee293fe996db01d7d663b8108fa0e1ff436219d2"
-  integrity sha512-4XywtdhwZwCpPJ/qfAkqExRsERW+UaoSRStSHCCiQTUpoYdLukj+YJbQSFrZjhlUDRZeNiU9SFH0u7iNimdiIg==
+"@jest/environment@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.2.0.tgz#48d1dbfa65f8e4a5a5c6cbeb9c59d1a5c2776f6b"
+  integrity sha512-iPWmQI0wRIYSZX3wKu4FXHK4eIqkfq6n1DCDJS+v3uby7SOXrHvX4eiTBuEdSvtDRMTIH2kjrSkjHf/F9JIYyQ==
   dependencies:
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/fake-timers" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
-    jest-mock "^27.0.6"
+    jest-mock "^27.1.1"
 
-"@jest/fake-timers@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.0.6.tgz#cbad52f3fe6abe30e7acb8cd5fa3466b9588e3df"
-  integrity sha512-sqd+xTWtZ94l3yWDKnRTdvTeZ+A/V7SSKrxsrOKSqdyddb9CeNRF8fbhAU0D7ZJBpTTW2nbp6MftmKJDZfW2LQ==
+"@jest/fake-timers@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.2.0.tgz#560841bc21ae7fbeff0cbff8de8f5cf43ad3561d"
+  integrity sha512-gSu3YHvQOoVaTWYGgHFB7IYFtcF2HBzX4l7s47VcjvkUgL4/FBnE20x7TNLa3W6ABERtGd5gStSwsA8bcn+c4w==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     "@sinonjs/fake-timers" "^7.0.2"
     "@types/node" "*"
-    jest-message-util "^27.0.6"
-    jest-mock "^27.0.6"
-    jest-util "^27.0.6"
+    jest-message-util "^27.2.0"
+    jest-mock "^27.1.1"
+    jest-util "^27.2.0"
 
-"@jest/globals@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.0.6.tgz#48e3903f99a4650673d8657334d13c9caf0e8f82"
-  integrity sha512-DdTGCP606rh9bjkdQ7VvChV18iS7q0IMJVP1piwTWyWskol4iqcVwthZmoJEf7obE1nc34OpIyoVGPeqLC+ryw==
+"@jest/globals@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.2.0.tgz#4d7085f51df5ac70c8240eb3501289676503933d"
+  integrity sha512-raqk9Gf9WC3hlBa57rmRmJfRl9hom2b+qEE/ifheMtwn5USH5VZxzrHHOZg0Zsd/qC2WJ8UtyTwHKQAnNlDMdg==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    expect "^27.0.6"
+    "@jest/environment" "^27.2.0"
+    "@jest/types" "^27.1.1"
+    expect "^27.2.0"
 
-"@jest/reporters@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.0.6.tgz#91e7f2d98c002ad5df94d5b5167c1eb0b9fd5b00"
-  integrity sha512-TIkBt09Cb2gptji3yJXb3EE+eVltW6BjO7frO7NEfjI9vSIYoISi5R3aI3KpEDXlB1xwB+97NXIqz84qYeYsfA==
+"@jest/reporters@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.2.0.tgz#629886d9a42218e504a424889a293abb27919e25"
+  integrity sha512-7wfkE3iRTLaT0F51h1mnxH3nQVwDCdbfgXiLuCcNkF1FnxXLH9utHqkSLIiwOTV1AtmiE0YagHbOvx4rnMP/GA==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.0"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
@@ -481,10 +515,10 @@
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.0.2"
-    jest-haste-map "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-util "^27.0.6"
-    jest-worker "^27.0.6"
+    jest-haste-map "^27.2.0"
+    jest-resolve "^27.2.0"
+    jest-util "^27.2.0"
+    jest-worker "^27.2.0"
     slash "^3.0.0"
     source-map "^0.6.0"
     string-length "^4.0.1"
@@ -500,41 +534,41 @@
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
 
-"@jest/test-result@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.0.6.tgz#3fa42015a14e4fdede6acd042ce98c7f36627051"
-  integrity sha512-ja/pBOMTufjX4JLEauLxE3LQBPaI2YjGFtXexRAjt1I/MbfNlMx0sytSX3tn5hSLzQsR3Qy2rd0hc1BWojtj9w==
+"@jest/test-result@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.2.0.tgz#377b46a41a6415dd4839fd0bed67b89fecea6b20"
+  integrity sha512-JPPqn8h0RGr4HyeY1Km+FivDIjTFzDROU46iAvzVjD42ooGwYoqYO/MQTilhfajdz6jpVnnphFrKZI5OYrBONA==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.0.6.tgz#80a913ed7a1130545b1cd777ff2735dd3af5d34b"
-  integrity sha512-bISzNIApazYOlTHDum9PwW22NOyDa6VI31n6JucpjTVM0jD6JDgqEZ9+yn575nDdPF0+4csYDxNNW13NvFQGZA==
+"@jest/test-sequencer@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.2.0.tgz#b02b507687825af2fdc84e90c539d36fd8cf7bc9"
+  integrity sha512-PrqarcpzOU1KSAK7aPwfL8nnpaqTMwPe7JBPnaOYRDSe/C6AoJiL5Kbnonqf1+DregxZIRAoDg69R9/DXMGqXA==
   dependencies:
-    "@jest/test-result" "^27.0.6"
+    "@jest/test-result" "^27.2.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.0.6"
-    jest-runtime "^27.0.6"
+    jest-haste-map "^27.2.0"
+    jest-runtime "^27.2.0"
 
-"@jest/transform@^27.0.6":
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.0.6.tgz#189ad7107413208f7600f4719f81dd2f7278cc95"
-  integrity sha512-rj5Dw+mtIcntAUnMlW/Vju5mr73u8yg+irnHwzgtgoeI6cCPOvUwQ0D1uQtc/APmWgvRweEb1g05pkUpxH3iCA==
+"@jest/transform@^27.2.0":
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.2.0.tgz#e7e6e49d2591792db2385c33cdbb4379d407068d"
+  integrity sha512-Q8Q/8xXIZYllk1AF7Ou5sV3egOZsdY/Wlv09CSbcexBRcC1Qt6lVZ7jRFAZtbHsEEzvOCyFEC4PcrwKwyjXtCg==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     babel-plugin-istanbul "^6.0.0"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.0.6"
+    jest-haste-map "^27.2.0"
     jest-regex-util "^27.0.6"
-    jest-util "^27.0.6"
+    jest-util "^27.2.0"
     micromatch "^4.0.4"
     pirates "^4.0.1"
     slash "^3.0.0"
@@ -545,6 +579,17 @@
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.6.tgz#9a992bc517e0c49f035938b8549719c2de40706b"
   integrity sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.1.tgz#77a3fc014f906c65752d12123a0134359707c0ad"
+  integrity sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -684,15 +729,20 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.8.tgz#edf1bf1dbf4e04413ca8e5b17b3b7d7d54b59818"
   integrity sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/node@*":
   version "16.3.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.3.2.tgz#655432817f83b51ac869c2d51dd8305fb8342e16"
   integrity sha512-jJs9ErFLP403I+hMLGnqDRWT0RYKSvArxuBVh2veudHV7ifEC1WAmjJADacZ7mRbA2nWgHtn8xyECMAot0SkAw==
 
-"@types/node@^16.6.1":
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.6.1.tgz#aee62c7b966f55fc66c7b6dfa1d58db2a616da61"
-  integrity sha512-Sr7BhXEAer9xyGuCN3Ek9eg9xPviCF2gfu9kTfuU2HkTVAMYSDeX40fvpmo72n5nansg3nsBjuQBrsS28r+NUw==
+"@types/node@^16.9.2":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.2.tgz#81f5a039d6ed1941f8cc57506c74e7c2b8fc64b9"
+  integrity sha512-ZHty/hKoOLZvSz6BtP1g7tc7nUeJhoCf3flLjh8ZEv1vFKBWHXcnMbJMyN/pftSljNyy0kNW/UqI3DccnBnZ8w==
 
 "@types/prettier@2.3.2", "@types/prettier@^2.1.5":
   version "2.3.2"
@@ -716,28 +766,28 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.2.tgz#f54dc0a32b8f61c6024ab8755da05363b733838d"
-  integrity sha512-x4EMgn4BTfVd9+Z+r+6rmWxoAzBaapt4QFqE+d8L8sUtYZYLDTK6VG/y/SMMWA5t1/BVU5Kf+20rX4PtWzUYZg==
+"@typescript-eslint/eslint-plugin@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.1.tgz#e938603a136f01dcabeece069da5fb2e331d4498"
+  integrity sha512-UDqhWmd5i0TvPLmbK5xY3UZB0zEGseF+DHPghZ37Sb83Qd3p8ujhvAtkU4OF46Ka5Pm5kWvFIx0cCTBFKo0alA==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.29.2"
-    "@typescript-eslint/scope-manager" "4.29.2"
+    "@typescript-eslint/experimental-utils" "4.31.1"
+    "@typescript-eslint/scope-manager" "4.31.1"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.2.tgz#5f67fb5c5757ef2cb3be64817468ba35c9d4e3b7"
-  integrity sha512-P6mn4pqObhftBBPAv4GQtEK7Yos1fz/MlpT7+YjH9fTxZcALbiiPKuSIfYP/j13CeOjfq8/fr9Thr2glM9ub7A==
+"@typescript-eslint/experimental-utils@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.1.tgz#0c900f832f270b88e13e51753647b02d08371ce5"
+  integrity sha512-NtoPsqmcSsWty0mcL5nTZXMf7Ei0Xr2MT8jWjXMVgRK0/1qeQ2jZzLFUh4QtyJ4+/lPUyMw5cSfeeME+Zrtp9Q==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.29.2"
-    "@typescript-eslint/types" "4.29.2"
-    "@typescript-eslint/typescript-estree" "4.29.2"
+    "@typescript-eslint/scope-manager" "4.31.1"
+    "@typescript-eslint/types" "4.31.1"
+    "@typescript-eslint/typescript-estree" "4.31.1"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -753,14 +803,14 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.29.2.tgz#1c7744f4c27aeb74610c955d3dce9250e95c370a"
-  integrity sha512-WQ6BPf+lNuwteUuyk1jD/aHKqMQ9jrdCn7Gxt9vvBnzbpj7aWEf+aZsJ1zvTjx5zFxGCt000lsbD9tQPEL8u6g==
+"@typescript-eslint/parser@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.31.1.tgz#8f9a2672033e6f6d33b1c0260eebdc0ddf539064"
+  integrity sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.29.2"
-    "@typescript-eslint/types" "4.29.2"
-    "@typescript-eslint/typescript-estree" "4.29.2"
+    "@typescript-eslint/scope-manager" "4.31.1"
+    "@typescript-eslint/types" "4.31.1"
+    "@typescript-eslint/typescript-estree" "4.31.1"
     debug "^4.3.1"
 
 "@typescript-eslint/scope-manager@4.29.0":
@@ -771,23 +821,23 @@
     "@typescript-eslint/types" "4.29.0"
     "@typescript-eslint/visitor-keys" "4.29.0"
 
-"@typescript-eslint/scope-manager@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz#442b0f029d981fa402942715b1718ac7fcd5aa1b"
-  integrity sha512-mfHmvlQxmfkU8D55CkZO2sQOueTxLqGvzV+mG6S/6fIunDiD2ouwsAoiYCZYDDK73QCibYjIZmGhpvKwAB5BOA==
+"@typescript-eslint/scope-manager@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.31.1.tgz#0c21e8501f608d6a25c842fcf59541ef4f1ab561"
+  integrity sha512-N1Uhn6SqNtU2XpFSkD4oA+F0PfKdWHyr4bTX0xTj8NRx1314gBDRL1LUuZd5+L3oP+wo6hCbZpaa1in6SwMcVQ==
   dependencies:
-    "@typescript-eslint/types" "4.29.2"
-    "@typescript-eslint/visitor-keys" "4.29.2"
+    "@typescript-eslint/types" "4.31.1"
+    "@typescript-eslint/visitor-keys" "4.31.1"
 
 "@typescript-eslint/types@4.29.0":
   version "4.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.0.tgz#c8f1a1e4441ea4aca9b3109241adbc145f7f8a4e"
   integrity sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==
 
-"@typescript-eslint/types@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.2.tgz#fc0489c6b89773f99109fb0aa0aaddff21f52fcd"
-  integrity sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==
+"@typescript-eslint/types@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.31.1.tgz#5f255b695627a13401d2fdba5f7138bc79450d66"
+  integrity sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==
 
 "@typescript-eslint/typescript-estree@4.29.0":
   version "4.29.0"
@@ -802,13 +852,13 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.2.tgz#a0ea8b98b274adbb2577100ba545ddf8bf7dc219"
-  integrity sha512-TJ0/hEnYxapYn9SGn3dCnETO0r+MjaxtlWZ2xU+EvytF0g4CqTpZL48SqSNn2hXsPolnewF30pdzR9a5Lj3DNg==
+"@typescript-eslint/typescript-estree@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.1.tgz#4a04d5232cf1031232b7124a9c0310b577a62d17"
+  integrity sha512-EGHkbsUvjFrvRnusk6yFGqrqMBTue5E5ROnS5puj3laGQPasVUgwhrxfcgkdHNFECHAewpvELE1Gjv0XO3mdWg==
   dependencies:
-    "@typescript-eslint/types" "4.29.2"
-    "@typescript-eslint/visitor-keys" "4.29.2"
+    "@typescript-eslint/types" "4.31.1"
+    "@typescript-eslint/visitor-keys" "4.31.1"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
@@ -823,12 +873,12 @@
     "@typescript-eslint/types" "4.29.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@4.29.2":
-  version "4.29.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.2.tgz#d2da7341f3519486f50655159f4e5ecdcb2cd1df"
-  integrity sha512-bDgJLQ86oWHJoZ1ai4TZdgXzJxsea3Ee9u9wsTAvjChdj2WLcVsgWYAPeY7RQMn16tKrlQaBnpKv7KBfs4EQag==
+"@typescript-eslint/visitor-keys@4.31.1":
+  version "4.31.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz#f2e7a14c7f20c4ae07d7fc3c5878c4441a1da9cc"
+  integrity sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==
   dependencies:
-    "@typescript-eslint/types" "4.29.2"
+    "@typescript-eslint/types" "4.31.1"
     eslint-visitor-keys "^2.0.0"
 
 abab@^2.0.3, abab@^2.0.5:
@@ -901,7 +951,7 @@ ansi-colors@^4.1.1:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -987,16 +1037,21 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-babel-jest@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.0.6.tgz#e99c6e0577da2655118e3608b68761a5a69bd0d8"
-  integrity sha512-iTJyYLNc4wRofASmofpOc5NK9QunwMk+TLFgGXsTFS8uEqmd8wdI7sga0FPe2oVH3b5Agt/EAK1QjPEuKL8VfA==
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
+babel-jest@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.2.0.tgz#c0f129a81f1197028aeb4447acbc04564c8bfc52"
+  integrity sha512-bS2p+KGGVVmWXBa8+i6SO/xzpiz2Q/2LnqLbQknPKefWXVZ67YIjA4iXup/jMOEZplga9PpWn+wrdb3UdDwRaA==
   dependencies:
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/transform" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.0.0"
-    babel-preset-jest "^27.0.6"
+    babel-preset-jest "^27.2.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
     slash "^3.0.0"
@@ -1012,10 +1067,10 @@ babel-plugin-istanbul@^6.0.0:
     istanbul-lib-instrument "^4.0.0"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.0.6.tgz#f7c6b3d764af21cb4a2a1ab6870117dbde15b456"
-  integrity sha512-CewFeM9Vv2gM7Yr9n5eyyLVPRSiBnk6lKZRjgwYnGKSl9M14TMn2vkN02wTF04OGuSDLEzlWiMzvjXuW9mB6Gw==
+babel-plugin-jest-hoist@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz#79f37d43f7e5c4fdc4b2ca3e10cc6cf545626277"
+  integrity sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -1040,18 +1095,42 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.0.6.tgz#909ef08e9f24a4679768be2f60a3df0856843f9d"
-  integrity sha512-WObA0/Biw2LrVVwZkF/2GqbOdzhKD6Fkdwhoy9ASIrOWr/zodcSpQh72JOkEn6NWyjmnPDjNSqaGN4KnpKzhXw==
+babel-preset-jest@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz#556bbbf340608fed5670ab0ea0c8ef2449fba885"
+  integrity sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==
   dependencies:
-    babel-plugin-jest-hoist "^27.0.6"
+    babel-plugin-jest-hoist "^27.2.0"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  integrity sha1-CfPeMckWQl1JjMLuVloOvzwqVik=
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
+benny@3.6.15:
+  version "3.6.15"
+  resolved "https://registry.yarnpkg.com/benny/-/benny-3.6.15.tgz#930826819b89546b274febe803da2d248a676caa"
+  integrity sha512-kq6XVGGYVou3Y8KNPs3SEF881vi5fJ8sIf9w69D2rreiNfRicWVWK6u6/mObMw6BiexoHHumtipn5gcu0Tngng==
+  dependencies:
+    "@arrows/composition" "^1.0.0"
+    "@arrows/dispatch" "^1.0.2"
+    "@arrows/multimethod" "^1.1.6"
+    benchmark "^2.1.4"
+    fs-extra "^9.0.1"
+    json2csv "^5.0.4"
+    kleur "^4.1.3"
+    log-update "^4.0.0"
+    prettier "^2.1.2"
+    stats-median "^1.0.1"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1163,6 +1242,13 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz#2fd46d9906a126965aa541345c499aaa18e8cd73"
   integrity sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==
 
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
 cliui@^7.0.2:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
@@ -1218,6 +1304,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
 complex.js@^2.0.11:
   version "2.0.15"
   resolved "https://registry.yarnpkg.com/complex.js/-/complex.js-2.0.15.tgz#7add6848b4c1d12aa9262f7df925ebe7a51a7406"
@@ -1228,7 +1319,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-console-table-printer@^2.10.0:
+console-table-printer@2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/console-table-printer/-/console-table-printer-2.10.0.tgz#4a6875b95071b36542d1c55c6d9dcc6206e1e9f0"
   integrity sha512-7pTsysaJs1+R+OO4cCtJbl+Lr4piHYIhi7/V1qHbOg/uiYgq2yUINFgvXZtVHqm9qpW0+Uk190qkGcKvzdunvg==
@@ -1480,7 +1571,7 @@ eslint-config-prettier@8.3.0:
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz#f7471b20b6fe8a9a9254cc684454202886a2dd7a"
   integrity sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==
 
-eslint-import-resolver-node@^0.3.5:
+eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz#4048b958395da89668252001dbd9eca6b83bacbd"
   integrity sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==
@@ -1514,38 +1605,38 @@ eslint-plugin-filenames@1.3.2:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
-eslint-plugin-import@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz#697ffd263e24da5e84e03b282f5fb62251777177"
-  integrity sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==
+eslint-plugin-import@2.24.2:
+  version "2.24.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz#2c8cd2e341f3885918ee27d18479910ade7bb4da"
+  integrity sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==
   dependencies:
     array-includes "^3.1.3"
     array.prototype.flat "^1.2.4"
     debug "^2.6.9"
     doctrine "^2.1.0"
-    eslint-import-resolver-node "^0.3.5"
+    eslint-import-resolver-node "^0.3.6"
     eslint-module-utils "^2.6.2"
     find-up "^2.0.0"
     has "^1.0.3"
-    is-core-module "^2.4.0"
+    is-core-module "^2.6.0"
     minimatch "^3.0.4"
-    object.values "^1.1.3"
+    object.values "^1.1.4"
     pkg-up "^2.0.0"
     read-pkg-up "^3.0.0"
     resolve "^1.20.0"
-    tsconfig-paths "^3.9.0"
+    tsconfig-paths "^3.11.0"
 
-eslint-plugin-jest@24.4.0:
-  version "24.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.4.0.tgz#fa4b614dbd46a98b652d830377971f097bda9262"
-  integrity sha512-8qnt/hgtZ94E9dA6viqfViKBfkJwFHXgJmTWlMGDgunw1XJEGqm3eiPjDsTanM3/u/3Az82nyQM9GX7PM/QGmg==
+eslint-plugin-jest@24.4.2:
+  version "24.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-24.4.2.tgz#9e8cf05ee6a0e3025e6149df2f36950abfa8d5bf"
+  integrity sha512-jNMnqwX75z0RXRMXkxwb/+9ylKJYJLJ8nT8nBT0XFM5qx4IQGxP4edMawa0qGkSbHae0BDPBmi8I2QF0/F04XQ==
   dependencies:
     "@typescript-eslint/experimental-utils" "^4.0.1"
 
-eslint-plugin-prettier@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"
-  integrity sha512-UDK6rJT6INSfcOo545jiaOwB701uAIt2/dR7WnFQoGCVl1/EMqdANBmwUaqqQ45aXprsTGzSa39LI1PyuRBxxw==
+eslint-plugin-prettier@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
+  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -1690,16 +1781,16 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expect@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.0.6.tgz#a4d74fbe27222c718fff68ef49d78e26a8fd4c05"
-  integrity sha512-psNLt8j2kwg42jGBDSfAlU49CEZxejN1f1PlANWDZqIhBOVU/c2Pm888FcjWJzFewhIsNWfZJeLjUjtKGiPuSw==
+expect@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.2.0.tgz#40eb89a492afb726a3929ccf3611ee0799ab976f"
+  integrity sha512-oOTbawMQv7AK1FZURbPTgGSzmhxkjFzoARSvDjOMnOpeWuYQx1tP6rXu9MIX5mrACmyCAM7fSNP8IJO2f1p0CQ==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     ansi-styles "^5.0.0"
     jest-get-type "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
     jest-regex-util "^27.0.6"
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
@@ -1803,6 +1894,16 @@ fraction.js@^4.0.12:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.1.1.tgz#ac4e520473dae67012d618aab91eda09bcb400ff"
   integrity sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg==
 
+fs-extra@^9.0.1:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1899,6 +2000,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
+  integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
 has-bigints@^1.0.1:
   version "1.0.1"
@@ -2046,10 +2152,17 @@ is-ci@^3.0.0:
   dependencies:
     ci-info "^3.1.1"
 
-is-core-module@^2.2.0, is-core-module@^2.4.0:
+is-core-module@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.5.0.tgz#f754843617c70bfd29b7bd87327400cda5c18491"
   integrity sha512-TXCMSDsEHMEEZ6eCA8rwRDbLu55MRGmrctljsBX/2v1d9/GzqHOxW5c5oPSgrUt2vBFXebu9rGqckXGPWOlYpg==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.6.0.tgz#d7553b2526fe59b92ba3e40c8df757ec8a709e19"
+  integrity sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==
   dependencies:
     has "^1.0.3"
 
@@ -2181,86 +2294,86 @@ javascript-natural-sort@^0.7.1:
   resolved "https://registry.yarnpkg.com/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz#f9e2303d4507f6d74355a73664d1440fb5a0ef59"
   integrity sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k=
 
-jest-changed-files@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.0.6.tgz#bed6183fcdea8a285482e3b50a9a7712d49a7a8b"
-  integrity sha512-BuL/ZDauaq5dumYh5y20sn4IISnf1P9A0TDswTxUi84ORGtVa86ApuBHqICL0vepqAnZiY6a7xeSPWv2/yy4eA==
+jest-changed-files@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.1.1.tgz#9b3f67a34cc58e3e811e2e1e21529837653e4200"
+  integrity sha512-5TV9+fYlC2A6hu3qtoyGHprBwCAn0AuGA77bZdUgYvVlRMjHXo063VcWTEAyx6XAZ85DYHqp0+aHKbPlfRDRvA==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     execa "^5.0.0"
     throat "^6.0.1"
 
-jest-circus@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.0.6.tgz#dd4df17c4697db6a2c232aaad4e9cec666926668"
-  integrity sha512-OJlsz6BBeX9qR+7O9lXefWoc2m9ZqcZ5Ohlzz0pTEAG4xMiZUJoacY8f4YDHxgk0oKYxj277AfOk9w6hZYvi1Q==
+jest-circus@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.2.0.tgz#ad0d6d75514050f539d422bae41344224d2328f9"
+  integrity sha512-WwENhaZwOARB1nmcboYPSv/PwHBUGRpA4MEgszjr9DLCl97MYw0qZprBwLb7rNzvMwfIvNGG7pefQ5rxyBlzIA==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/environment" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
-    expect "^27.0.6"
+    expect "^27.2.0"
     is-generator-fn "^2.0.0"
-    jest-each "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-each "^27.2.0"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-runtime "^27.2.0"
+    jest-snapshot "^27.2.0"
+    jest-util "^27.2.0"
+    pretty-format "^27.2.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
-jest-cli@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.0.6.tgz#d021e5f4d86d6a212450d4c7b86cb219f1e6864f"
-  integrity sha512-qUUVlGb9fdKir3RDE+B10ULI+LQrz+MCflEH2UJyoUjoHHCbxDrMxSzjQAPUMsic4SncI62ofYCcAvW6+6rhhg==
+jest-cli@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.2.0.tgz#6da5ecca5bd757e20449f5ec1f1cad5b0303d16b"
+  integrity sha512-bq1X/B/b1kT9y1zIFMEW3GFRX1HEhFybiqKdbxM+j11XMMYSbU9WezfyWIhrSOmPT+iODLATVjfsCnbQs7cfIA==
   dependencies:
-    "@jest/core" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/core" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     import-local "^3.0.2"
-    jest-config "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    jest-config "^27.2.0"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
     prompts "^2.0.1"
     yargs "^16.0.3"
 
-jest-config@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.0.6.tgz#119fb10f149ba63d9c50621baa4f1f179500277f"
-  integrity sha512-JZRR3I1Plr2YxPBhgqRspDE2S5zprbga3swYNrvY3HfQGu7p/GjyLOqwrYad97tX3U3mzT53TPHVmozacfP/3w==
+jest-config@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.2.0.tgz#d1c359253927005c53d11ab3e50d3b2f402a673a"
+  integrity sha512-Z1romHpxeNwLxQtouQ4xt07bY6HSFGKTo0xJcvOK3u6uJHveA4LB2P+ty9ArBLpTh3AqqPxsyw9l9GMnWBYS9A==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^27.0.6"
-    "@jest/types" "^27.0.6"
-    babel-jest "^27.0.6"
+    "@jest/test-sequencer" "^27.2.0"
+    "@jest/types" "^27.1.1"
+    babel-jest "^27.2.0"
     chalk "^4.0.0"
     deepmerge "^4.2.2"
     glob "^7.1.1"
     graceful-fs "^4.2.4"
     is-ci "^3.0.0"
-    jest-circus "^27.0.6"
-    jest-environment-jsdom "^27.0.6"
-    jest-environment-node "^27.0.6"
+    jest-circus "^27.2.0"
+    jest-environment-jsdom "^27.2.0"
+    jest-environment-node "^27.2.0"
     jest-get-type "^27.0.6"
-    jest-jasmine2 "^27.0.6"
+    jest-jasmine2 "^27.2.0"
     jest-regex-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-runner "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    jest-resolve "^27.2.0"
+    jest-runner "^27.2.0"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
     micromatch "^4.0.4"
-    pretty-format "^27.0.6"
+    pretty-format "^27.2.0"
 
-jest-diff@^27.0.0, jest-diff@^27.0.6:
+jest-diff@^27.0.0:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.0.6.tgz#4a7a19ee6f04ad70e0e3388f35829394a44c7b5e"
   integrity sha512-Z1mqgkTCSYaFgwTlP/NUiRzdqgxmmhzHY1Tq17zL94morOHfHu3K4bgSgl+CR4GLhpV8VxkuOYuIWnQ9LnFqmg==
@@ -2270,6 +2383,16 @@ jest-diff@^27.0.0, jest-diff@^27.0.6:
     jest-get-type "^27.0.6"
     pretty-format "^27.0.6"
 
+jest-diff@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.2.0.tgz#bda761c360f751bab1e7a2fe2fc2b0a35ce8518c"
+  integrity sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.0.6"
+    jest-get-type "^27.0.6"
+    pretty-format "^27.2.0"
+
 jest-docblock@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.0.6.tgz#cc78266acf7fe693ca462cbbda0ea4e639e4e5f3"
@@ -2277,53 +2400,53 @@ jest-docblock@^27.0.6:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.0.6.tgz#cee117071b04060158dc8d9a66dc50ad40ef453b"
-  integrity sha512-m6yKcV3bkSWrUIjxkE9OC0mhBZZdhovIW5ergBYirqnkLXkyEn3oUUF/QZgyecA1cF1QFyTE8bRRl8Tfg1pfLA==
+jest-each@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.2.0.tgz#4c531c7223de289429fc7b2473a86e653c86d61f"
+  integrity sha512-biDmmUQjg+HZOB7MfY2RHSFL3j418nMoC3TK3pGAj880fQQSxvQe1y2Wy23JJJNUlk6YXiGU0yWy86Le1HBPmA==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     jest-get-type "^27.0.6"
-    jest-util "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-util "^27.2.0"
+    pretty-format "^27.2.0"
 
-jest-environment-jsdom@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.0.6.tgz#f66426c4c9950807d0a9f209c590ce544f73291f"
-  integrity sha512-FvetXg7lnXL9+78H+xUAsra3IeZRTiegA3An01cWeXBspKXUhAwMM9ycIJ4yBaR0L7HkoMPaZsozCLHh4T8fuw==
+jest-environment-jsdom@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.2.0.tgz#c654dfae50ca2272c2a2e2bb95ff0af298283a3c"
+  integrity sha512-wNQJi6Rd/AkUWqTc4gWhuTIFPo7tlMK0RPZXeM6AqRHZA3D3vwvTa9ktAktyVyWYmUoXdYstOfyYMG3w4jt7eA==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/environment" "^27.2.0"
+    "@jest/fake-timers" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
-    jest-mock "^27.0.6"
-    jest-util "^27.0.6"
+    jest-mock "^27.1.1"
+    jest-util "^27.2.0"
     jsdom "^16.6.0"
 
-jest-environment-node@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.0.6.tgz#a6699b7ceb52e8d68138b9808b0c404e505f3e07"
-  integrity sha512-+Vi6yLrPg/qC81jfXx3IBlVnDTI6kmRr08iVa2hFCWmJt4zha0XW7ucQltCAPhSR0FEKEoJ3i+W4E6T0s9is0w==
+jest-environment-node@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.2.0.tgz#73ef2151cb62206669becb94cd84f33276252de5"
+  integrity sha512-WbW+vdM4u88iy6Q3ftUEQOSgMPtSgjm3qixYYK2AKEuqmFO2zmACTw1vFUB0qI/QN88X6hA6ZkVKIdIWWzz+yg==
   dependencies:
-    "@jest/environment" "^27.0.6"
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/environment" "^27.2.0"
+    "@jest/fake-timers" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
-    jest-mock "^27.0.6"
-    jest-util "^27.0.6"
+    jest-mock "^27.1.1"
+    jest-util "^27.2.0"
 
 jest-get-type@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
   integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
 
-jest-haste-map@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.0.6.tgz#4683a4e68f6ecaa74231679dca237279562c8dc7"
-  integrity sha512-4ldjPXX9h8doB2JlRzg9oAZ2p6/GpQUNAeiYXqcpmrKbP0Qev0wdZlxSMOmz8mPOEnt4h6qIzXFLDi8RScX/1w==
+jest-haste-map@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.2.0.tgz#703b3a473e3f2e27d75ab07864ffd7bbaad0d75e"
+  integrity sha512-laFet7QkNlWjwZtMGHCucLvF8o9PAh2cgePRck1+uadSM4E4XH9J4gnx4do+a6do8ZV5XHNEAXEkIoNg5XUH2Q==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     "@types/graceful-fs" "^4.1.2"
     "@types/node" "*"
     anymatch "^3.0.3"
@@ -2331,76 +2454,76 @@ jest-haste-map@^27.0.6:
     graceful-fs "^4.2.4"
     jest-regex-util "^27.0.6"
     jest-serializer "^27.0.6"
-    jest-util "^27.0.6"
-    jest-worker "^27.0.6"
+    jest-util "^27.2.0"
+    jest-worker "^27.2.0"
     micromatch "^4.0.4"
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-jasmine2@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.0.6.tgz#fd509a9ed3d92bd6edb68a779f4738b100655b37"
-  integrity sha512-cjpH2sBy+t6dvCeKBsHpW41mjHzXgsavaFMp+VWRf0eR4EW8xASk1acqmljFtK2DgyIECMv2yCdY41r2l1+4iA==
+jest-jasmine2@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.2.0.tgz#1ece0ee37c348b59ed3dfcfe509fc24e3377b12d"
+  integrity sha512-NcPzZBk6IkDW3Z2V8orGueheGJJYfT5P0zI/vTO/Jp+R9KluUdgFrgwfvZ0A34Kw6HKgiWFILZmh3oQ/eS+UxA==
   dependencies:
     "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^27.0.6"
+    "@jest/environment" "^27.2.0"
     "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/test-result" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
-    expect "^27.0.6"
+    expect "^27.2.0"
     is-generator-fn "^2.0.0"
-    jest-each "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    pretty-format "^27.0.6"
+    jest-each "^27.2.0"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-runtime "^27.2.0"
+    jest-snapshot "^27.2.0"
+    jest-util "^27.2.0"
+    pretty-format "^27.2.0"
     throat "^6.0.1"
 
-jest-leak-detector@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.0.6.tgz#545854275f85450d4ef4b8fe305ca2a26450450f"
-  integrity sha512-2/d6n2wlH5zEcdctX4zdbgX8oM61tb67PQt4Xh8JFAIy6LRKUnX528HulkaG6nD5qDl5vRV1NXejCe1XRCH5gQ==
+jest-leak-detector@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.2.0.tgz#9a7ca2dad1a21c4e49ad2a8ad7f1214ffdb86a28"
+  integrity sha512-e91BIEmbZw5+MHkB4Hnrq7S86coTxUMCkz4n7DLmQYvl9pEKmRx9H/JFH87bBqbIU5B2Ju1soKxRWX6/eGFGpA==
   dependencies:
     jest-get-type "^27.0.6"
-    pretty-format "^27.0.6"
+    pretty-format "^27.2.0"
 
-jest-matcher-utils@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.0.6.tgz#2a8da1e86c620b39459f4352eaa255f0d43e39a9"
-  integrity sha512-OFgF2VCQx9vdPSYTHWJ9MzFCehs20TsyFi6bIHbk5V1u52zJOnvF0Y/65z3GLZHKRuTgVPY4Z6LVePNahaQ+tA==
+jest-matcher-utils@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.2.0.tgz#b4d224ab88655d5fab64b96b989ac349e2f5da43"
+  integrity sha512-F+LG3iTwJ0gPjxBX6HCyrARFXq6jjiqhwBQeskkJQgSLeF1j6ui1RTV08SR7O51XTUhtc8zqpDj8iCG4RGmdKw==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^27.0.6"
+    jest-diff "^27.2.0"
     jest-get-type "^27.0.6"
-    pretty-format "^27.0.6"
+    pretty-format "^27.2.0"
 
-jest-message-util@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.0.6.tgz#158bcdf4785706492d164a39abca6a14da5ab8b5"
-  integrity sha512-rBxIs2XK7rGy+zGxgi+UJKP6WqQ+KrBbD1YMj517HYN3v2BG66t3Xan3FWqYHKZwjdB700KiAJ+iES9a0M+ixw==
+jest-message-util@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.2.0.tgz#2f65c71df55267208686b1d7514e18106c91ceaf"
+  integrity sha512-y+sfT/94CiP8rKXgwCOzO1mUazIEdEhrLjuiu+RKmCP+8O/TJTSne9dqQRbFIHBtlR2+q7cddJlWGir8UATu5w==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
     micromatch "^4.0.4"
-    pretty-format "^27.0.6"
+    pretty-format "^27.2.0"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.0.6.tgz#0efdd40851398307ba16778728f6d34d583e3467"
-  integrity sha512-lzBETUoK8cSxts2NYXSBWT+EJNzmUVtVVwS1sU9GwE1DLCfGsngg+ZVSIe0yd0ZSm+y791esiuo+WSwpXJQ5Bw==
+jest-mock@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.1.1.tgz#c7a2e81301fdcf3dab114931d23d89ec9d0c3a82"
+  integrity sha512-SClsFKuYBf+6SSi8jtAYOuPw8DDMsTElUWEae3zq7vDhH01ayVSIHUSIa8UgbDOUalCFp6gNsaikN0rbxN4dbw==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -2413,86 +2536,88 @@ jest-regex-util@^27.0.6:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.0.6.tgz#02e112082935ae949ce5d13b2675db3d8c87d9c5"
   integrity sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==
 
-jest-resolve-dependencies@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.0.6.tgz#3e619e0ef391c3ecfcf6ef4056207a3d2be3269f"
-  integrity sha512-mg9x9DS3BPAREWKCAoyg3QucCr0n6S8HEEsqRCKSPjPcu9HzRILzhdzY3imsLoZWeosEbJZz6TKasveczzpJZA==
+jest-resolve-dependencies@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.2.0.tgz#b56a1aab95b0fd21e0a69a15fda985c05f902b8a"
+  integrity sha512-EY5jc/Y0oxn+oVEEldTidmmdVoZaknKPyDORA012JUdqPyqPL+lNdRyI3pGti0RCydds6coaw6xt4JQY54dKsg==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-snapshot "^27.0.6"
+    jest-snapshot "^27.2.0"
 
-jest-resolve@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.0.6.tgz#e90f436dd4f8fbf53f58a91c42344864f8e55bff"
-  integrity sha512-yKmIgw2LgTh7uAJtzv8UFHGF7Dm7XfvOe/LQ3Txv101fLM8cx2h1QVwtSJ51Q/SCxpIiKfVn6G2jYYMDNHZteA==
+jest-resolve@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.2.0.tgz#f5d053693ab3806ec2f778e6df8b0aa4cfaef95f"
+  integrity sha512-v09p9Ib/VtpHM6Cz+i9lEAv1Z/M5NVxsyghRHRMEUOqwPQs3zwTdwp1xS3O/k5LocjKiGS0OTaJoBSpjbM2Jlw==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     escalade "^3.1.1"
     graceful-fs "^4.2.4"
+    jest-haste-map "^27.2.0"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
     resolve "^1.20.0"
     slash "^3.0.0"
 
-jest-runner@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.0.6.tgz#1325f45055539222bbc7256a6976e993ad2f9520"
-  integrity sha512-W3Bz5qAgaSChuivLn+nKOgjqNxM7O/9JOJoKDCqThPIg2sH/d4A/lzyiaFgnb9V1/w29Le11NpzTJSzga1vyYQ==
+jest-runner@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.2.0.tgz#281b255d88a473aebc0b5cb46e58a83a1251cab3"
+  integrity sha512-Cl+BHpduIc0cIVTjwoyx0pQk4Br8gn+wkr35PmKCmzEdOUnQ2wN7QVXA8vXnMQXSlFkN/+KWnk20TAVBmhgrww==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/environment" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/console" "^27.2.0"
+    "@jest/environment" "^27.2.0"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     emittery "^0.8.1"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     jest-docblock "^27.0.6"
-    jest-environment-jsdom "^27.0.6"
-    jest-environment-node "^27.0.6"
-    jest-haste-map "^27.0.6"
-    jest-leak-detector "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-runtime "^27.0.6"
-    jest-util "^27.0.6"
-    jest-worker "^27.0.6"
+    jest-environment-jsdom "^27.2.0"
+    jest-environment-node "^27.2.0"
+    jest-haste-map "^27.2.0"
+    jest-leak-detector "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-resolve "^27.2.0"
+    jest-runtime "^27.2.0"
+    jest-util "^27.2.0"
+    jest-worker "^27.2.0"
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
-jest-runtime@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.0.6.tgz#45877cfcd386afdd4f317def551fc369794c27c9"
-  integrity sha512-BhvHLRVfKibYyqqEFkybsznKwhrsu7AWx2F3y9G9L95VSIN3/ZZ9vBpm/XCS2bS+BWz3sSeNGLzI3TVQ0uL85Q==
+jest-runtime@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.2.0.tgz#998295ccd80008b3031eeb5cc60e801e8551024b"
+  integrity sha512-6gRE9AVVX49hgBbWQ9PcNDeM4upMUXzTpBs0kmbrjyotyUyIJixLPsYjpeTFwAA07PVLDei1iAm2chmWycdGdQ==
   dependencies:
-    "@jest/console" "^27.0.6"
-    "@jest/environment" "^27.0.6"
-    "@jest/fake-timers" "^27.0.6"
-    "@jest/globals" "^27.0.6"
+    "@jest/console" "^27.2.0"
+    "@jest/environment" "^27.2.0"
+    "@jest/fake-timers" "^27.2.0"
+    "@jest/globals" "^27.2.0"
     "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.0.6"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/test-result" "^27.2.0"
+    "@jest/transform" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
     collect-v8-coverage "^1.0.0"
+    execa "^5.0.0"
     exit "^0.1.2"
     glob "^7.1.3"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-mock "^27.0.6"
+    jest-haste-map "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-mock "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-snapshot "^27.0.6"
-    jest-util "^27.0.6"
-    jest-validate "^27.0.6"
+    jest-resolve "^27.2.0"
+    jest-snapshot "^27.2.0"
+    jest-util "^27.2.0"
+    jest-validate "^27.2.0"
     slash "^3.0.0"
     strip-bom "^4.0.0"
     yargs "^16.0.3"
@@ -2505,10 +2630,10 @@ jest-serializer@^27.0.6:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-snapshot@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.0.6.tgz#f4e6b208bd2e92e888344d78f0f650bcff05a4bf"
-  integrity sha512-NTHaz8He+ATUagUgE7C/UtFcRoHqR2Gc+KDfhQIyx+VFgwbeEMjeP+ILpUTLosZn/ZtbNdCF5LkVnN/l+V751A==
+jest-snapshot@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.2.0.tgz#7961e7107ac666a46fbb23e7bb48ce0b8c6a9285"
+  integrity sha512-MukJvy3KEqemCT2FoT3Gum37CQqso/62PKTfIzWmZVTsLsuyxQmJd2PI5KPcBYFqLlA8LgZLHM8ZlazkVt8LsQ==
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/generator" "^7.7.2"
@@ -2516,26 +2641,26 @@ jest-snapshot@^27.0.6:
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/transform" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/babel__traverse" "^7.0.4"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^27.0.6"
+    expect "^27.2.0"
     graceful-fs "^4.2.4"
-    jest-diff "^27.0.6"
+    jest-diff "^27.2.0"
     jest-get-type "^27.0.6"
-    jest-haste-map "^27.0.6"
-    jest-matcher-utils "^27.0.6"
-    jest-message-util "^27.0.6"
-    jest-resolve "^27.0.6"
-    jest-util "^27.0.6"
+    jest-haste-map "^27.2.0"
+    jest-matcher-utils "^27.2.0"
+    jest-message-util "^27.2.0"
+    jest-resolve "^27.2.0"
+    jest-util "^27.2.0"
     natural-compare "^1.4.0"
-    pretty-format "^27.0.6"
+    pretty-format "^27.2.0"
     semver "^7.3.2"
 
-jest-util@^27.0.0, jest-util@^27.0.6:
+jest-util@^27.0.0:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.0.6.tgz#e8e04eec159de2f4d5f57f795df9cdc091e50297"
   integrity sha512-1JjlaIh+C65H/F7D11GNkGDDZtDfMEM8EBXsvd+l/cxtgQ6QhxuloOaiayt89DxUvDarbVhqI98HhgrM1yliFQ==
@@ -2547,48 +2672,60 @@ jest-util@^27.0.0, jest-util@^27.0.6:
     is-ci "^3.0.0"
     picomatch "^2.2.3"
 
-jest-validate@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.0.6.tgz#930a527c7a951927df269f43b2dc23262457e2a6"
-  integrity sha512-yhZZOaMH3Zg6DC83n60pLmdU1DQE46DW+KLozPiPbSbPhlXXaiUTDlhHQhHFpaqIFRrInko1FHXjTRpjWRuWfA==
+jest-util@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.2.0.tgz#bfccb85cfafae752257319e825a5b8d4ada470dc"
+  integrity sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==
   dependencies:
-    "@jest/types" "^27.0.6"
+    "@jest/types" "^27.1.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    is-ci "^3.0.0"
+    picomatch "^2.2.3"
+
+jest-validate@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.2.0.tgz#b7535f12d95dd3b4382831f4047384ca098642ab"
+  integrity sha512-uIEZGkFKk3+4liA81Xu0maG5aGDyPLdp+4ed244c+Ql0k3aLWQYcMbaMLXOIFcb83LPHzYzqQ8hwNnIxTqfAGQ==
+  dependencies:
+    "@jest/types" "^27.1.1"
     camelcase "^6.2.0"
     chalk "^4.0.0"
     jest-get-type "^27.0.6"
     leven "^3.1.0"
-    pretty-format "^27.0.6"
+    pretty-format "^27.2.0"
 
-jest-watcher@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.0.6.tgz#89526f7f9edf1eac4e4be989bcb6dec6b8878d9c"
-  integrity sha512-/jIoKBhAP00/iMGnTwUBLgvxkn7vsOweDrOTSPzc7X9uOyUtJIDthQBTI1EXz90bdkrxorUZVhJwiB69gcHtYQ==
+jest-watcher@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.2.0.tgz#dc2eef4c13c6d41cebf3f1fc5f900a54b51c2ea0"
+  integrity sha512-SjRWhnr+qO8aBsrcnYIyF+qRxNZk6MZH8TIDgvi+VlsyrvOyqg0d+Rm/v9KHiTtC9mGGeFi9BFqgavyWib6xLg==
   dependencies:
-    "@jest/test-result" "^27.0.6"
-    "@jest/types" "^27.0.6"
+    "@jest/test-result" "^27.2.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    jest-util "^27.0.6"
+    jest-util "^27.2.0"
     string-length "^4.0.1"
 
-jest-worker@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.6.tgz#a5fdb1e14ad34eb228cfe162d9f729cdbfa28aed"
-  integrity sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==
+jest-worker@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.2.0.tgz#11eef39f1c88f41384ca235c2f48fe50bc229bc0"
+  integrity sha512-laB0ZVIBz+voh/QQy9dmUuuDsadixeerrKqyVpgPz+CCWiOYjOBabUXHIXZhsdvkWbLqSHbgkAHWl5cg24Q6RA==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.0.6.tgz#10517b2a628f0409087fbf473db44777d7a04505"
-  integrity sha512-EjV8aETrsD0wHl7CKMibKwQNQc3gIRBXlTikBmmHUeVMKaPFxdcUIBfoDqTSXDoGJIivAYGqCWVlzCSaVjPQsA==
+jest@27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.2.0.tgz#3bc329287d699d26361e2094919630eefdf1ac0d"
+  integrity sha512-oUqVXyvh5YwEWl263KWdPUAqEzBFzGHdFLQ05hUnITr1tH+9SscEI9A/GH9eBClA+Nw1ct+KNuuOV6wlnmBPcg==
   dependencies:
-    "@jest/core" "^27.0.6"
+    "@jest/core" "^27.2.0"
     import-local "^3.0.2"
-    jest-cli "^27.0.6"
+    jest-cli "^27.2.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2661,14 +2798,44 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
-json5@2.x, json5@^2.1.2, json5@^2.2.0:
+json2csv@^5.0.4:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/json2csv/-/json2csv-5.0.6.tgz#590e0e1b9579e59baa53bda0c0d840f4d8009687"
+  integrity sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==
+  dependencies:
+    commander "^6.1.0"
+    jsonparse "^1.3.1"
+    lodash.get "^4.4.2"
+
+json5@2.x, json5@^2.1.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
-kelonio@^0.6.0:
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonparse@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
+  integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
+kelonio@0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/kelonio/-/kelonio-0.6.0.tgz#a58461b9fc0584b10037c64a02ce6fb770535edb"
   integrity sha512-9Ubwu2TDfNAFIsf+bmD7l6dK71o85F5ix00EEKHMH6ZSSzfh3h4yla5u9tCqdMlocIlQbZlVxotu8FMUmbFwzA==
@@ -2680,6 +2847,11 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+
+kleur@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
+  integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
 leven@^3.1.0:
   version "3.1.0"
@@ -2737,6 +2909,11 @@ lodash.clonedeep@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.get@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
 lodash.kebabcase@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
@@ -2762,10 +2939,20 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
-lodash@4.x, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-update@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"
+  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+  dependencies:
+    ansi-escapes "^4.3.0"
+    cli-cursor "^3.1.0"
+    slice-ansi "^4.0.0"
+    wrap-ansi "^6.2.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -2941,7 +3128,7 @@ object.assign@^4.1.2:
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
-object.values@^1.1.3:
+object.values@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.4.tgz#0d273762833e816b693a637d30073e7051535b30"
   integrity sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==
@@ -2957,7 +3144,7 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.2:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -3088,7 +3275,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-percentile@^1.5.0:
+percentile@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/percentile/-/percentile-1.5.0.tgz#6af7edebbe2578348ba81c4ebefd851b937dc130"
   integrity sha512-Hc98z8qBZ5+rHNuWUQ4PTfqAeq4ndnSwYH18PSIa4lMWIY2sITFS/EC6/cOFujgbN4pdc6sALO4HvahYNYnxwA==
@@ -3131,6 +3318,11 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+platform@^1.3.3:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
+  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -3148,10 +3340,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
-  integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+prettier@2.4.1, prettier@^2.1.2:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
+  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
 pretty-format@^27.0.0, pretty-format@^27.0.6:
   version "27.0.6"
@@ -3159,6 +3351,16 @@ pretty-format@^27.0.0, pretty-format@^27.0.6:
   integrity sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==
   dependencies:
     "@jest/types" "^27.0.6"
+    ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.2.0:
+  version "27.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.2.0.tgz#ee37a94ce2a79765791a8649ae374d468c18ef19"
+  integrity sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==
+  dependencies:
+    "@jest/types" "^27.1.1"
     ansi-regex "^5.0.0"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
@@ -3252,6 +3454,14 @@ resolve@^1.10.0, resolve@^1.20.0:
   dependencies:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
+
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -3412,6 +3622,11 @@ stack-utils@^2.0.3:
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+stats-median@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stats-median/-/stats-median-1.0.1.tgz#ca8497cb1014d23d145db4d6fc93c8e815eed3ef"
+  integrity sha512-IYsheLg6dasD3zT/w9+8Iq9tcIQqqu91ZIpJOnIEM25C3X/g4Tl8mhXwW2ZQpbrsJISr9+wizEYgsibN5/b32Q==
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -3598,10 +3813,10 @@ ts-jest@27.0.5:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-node@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.0.tgz#f1e88249a00e26aa95e9a93c50f70241a8a1c4bb"
-  integrity sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==
+ts-node@10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.2.1.tgz#4cc93bea0a7aba2179497e65bb08ddfc198b3ab5"
+  integrity sha512-hCnyOyuGmD5wHleOQX6NIjJtYVIO8bPP8F2acWkB4W06wdlkgyvJtubO/I9NkI88hCFECbsEgoLc0VNkYmcSfw==
   dependencies:
     "@cspotcode/source-map-support" "0.6.1"
     "@tsconfig/node10" "^1.0.7"
@@ -3616,12 +3831,13 @@ ts-node@10.2.0:
     make-error "^1.1.1"
     yn "3.1.1"
 
-tsconfig-paths@^3.9.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz#79ae67a68c15289fdf5c51cb74f397522d795ed7"
-  integrity sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==
+tsconfig-paths@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz#954c1fe973da6339c78e06b03ce2e48810b65f36"
+  integrity sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==
   dependencies:
-    json5 "^2.2.0"
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
@@ -3678,10 +3894,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
+  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -3697,6 +3913,11 @@ universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -3801,6 +4022,15 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Rather than using lazy message reading for each field when building
an object for toJSON, we use the regular message reader to read the
message. This improves performance drastically by avoiding the various
per field offset calculations.

Fixes: #8