### PR TITLE
Relax (Lazy)MessageReader interface to accept any ArrayBufferView

### DIFF
--- a/src/LazyMessageReader.ts
+++ b/src/LazyMessageReader.ts
@@ -28,8 +28,8 @@ export class LazyMessageReader<T = unknown> {
   }
 
   // Return the size of our message within the buffer
-  size(buffer: Readonly<Uint8Array>): number {
-    const view = new DataView(buffer.buffer, buffer.byteOffset);
+  size(buffer: ArrayBufferView): number {
+    const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
     return this.readerImpl.size(view);
   }
 
@@ -40,7 +40,7 @@ export class LazyMessageReader<T = unknown> {
   // Create a LazyMessage for the buffer
   // We template on R here for call site type information if the class type information T is not
   // known or available
-  readMessage<R = T>(buffer: Readonly<Uint8Array>): LazyMessage<R> {
+  readMessage<R = T>(buffer: ArrayBufferView): LazyMessage<R> {
     const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
     return this.readerImpl.build(view) as LazyMessage<R>;
   }


### PR DESCRIPTION
**Public-Facing Changes**
MessageReader and LazyMessageReader APIs now accept any ArrayBufferView (including DataView) instead of just Uint8Array.