### PR TITLE
Move class member initialization into the constructor for LazyMessageReader

### DIFF
--- a/bench/benny.ts
+++ b/bench/benny.ts
@@ -77,8 +77,8 @@ async function makeSuite(testCase: Testcase): Promise<void> {
 
     benny.add("Lazy", () => {
       const messageReader = new LazyMessageReader(messageDefinition);
-      const msg = messageReader.readMessage(msgData);
       return () => {
+        const msg = messageReader.readMessage(msgData);
         lastField(msg);
       };
     }),

--- a/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -40,31 +40,28 @@ exports[`LazyReader should deserialize CustomType custom
       return new custom_type_CustomType(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"custom_type/CustomType\\"))(reader);
     }
 
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
   }
 
@@ -98,31 +95,28 @@ exports[`LazyReader should deserialize CustomType custom
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get custom() {
-      const offset = this.custom_offset(this.#view, this.#offset);
-      return custom_type_CustomType.build(this.#view, offset);
+      const offset = this.custom_offset(this._view, this._offset);
+      return custom_type_CustomType.build(this._view, offset);
     }
   }
   return __RootMsg;
@@ -176,31 +170,28 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new custom_type_MoreCustom(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"custom_type/MoreCustom\\"))(reader);
     }
 
     get field() {
-      const offset = this.field_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.field_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
   }
 
@@ -234,31 +225,28 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new custom_type_CustomType(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"custom_type/CustomType\\"))(reader);
     }
 
     get another() {
-      const offset = this.another_offset(this.#view, this.#offset);
-      return custom_type_MoreCustom.build(this.#view, offset);
+      const offset = this.another_offset(this._view, this._offset);
+      return custom_type_MoreCustom.build(this._view, offset);
     }
   }
 
@@ -292,23 +280,20 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -316,9 +301,9 @@ exports[`LazyReader should deserialize CustomType[] custom
 
     // custom_type/CustomType[] custom
     get custom() {
-      const offset = this.custom_offset(this.#view, this.#offset);
+      const offset = this.custom_offset(this._view, this._offset);
       return deserializers.dynamicArray(
-        this.#view,
+        this._view,
         offset,
         custom_type_CustomType.build,
         custom_type_CustomType.size
@@ -370,31 +355,28 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new custom_type_CustomType(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"custom_type/CustomType\\"))(reader);
     }
 
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
   }
 
@@ -428,23 +410,20 @@ exports[`LazyReader should deserialize CustomType[] custom
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -452,9 +431,9 @@ exports[`LazyReader should deserialize CustomType[] custom
 
     // custom_type/CustomType[] custom
     get custom() {
-      const offset = this.custom_offset(this.#view, this.#offset);
+      const offset = this.custom_offset(this._view, this._offset);
       return deserializers.dynamicArray(
-        this.#view,
+        this._view,
         offset,
         custom_type_CustomType.build,
         custom_type_CustomType.size
@@ -506,31 +485,28 @@ exports[`LazyReader should deserialize CustomType[3] custom
       return new custom_type_CustomType(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"custom_type/CustomType\\"))(reader);
     }
 
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
   }
 
@@ -569,23 +545,20 @@ exports[`LazyReader should deserialize CustomType[3] custom
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -593,9 +566,9 @@ exports[`LazyReader should deserialize CustomType[3] custom
 
     // custom_type/CustomType[3] custom
     get custom() {
-      const offset = this.custom_offset(this.#view, this.#offset);
+      const offset = this.custom_offset(this._view, this._offset);
       return deserializers.fixedArray(
-        this.#view,
+        this._view,
         offset,
         3,
         custom_type_CustomType.build,
@@ -642,31 +615,28 @@ exports[`LazyReader should deserialize duration stamp: duration stamp 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get stamp() {
-      const offset = this.stamp_offset(this.#view, this.#offset);
-      return deserializers.duration(this.#view, offset);
+      const offset = this.stamp_offset(this._view, this._offset);
+      return deserializers.duration(this._view, offset);
     }
   }
   return __RootMsg;
@@ -712,23 +682,20 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -736,9 +703,9 @@ exports[`LazyReader should deserialize duration[] arr: duration[] arr 1`] = `
 
     // duration[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.durationArray(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.durationArray(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -780,23 +747,20 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -804,8 +768,8 @@ exports[`LazyReader should deserialize duration[1] arr: duration[1] arr 1`] = `
 
     // duration[1] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      return deserializers.durationArray(this.#view, offset, 1);
+      const offset = this.arr_offset(this._view, this._offset);
+      return deserializers.durationArray(this._view, offset, 1);
     }
   }
   return __RootMsg;
@@ -847,31 +811,28 @@ exports[`LazyReader should deserialize float32 sample: float32 sample 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.float32(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.float32(this._view, offset);
     }
   }
   return __RootMsg;
@@ -917,23 +878,20 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -941,9 +899,9 @@ exports[`LazyReader should deserialize float32[] arr: float32[] arr 1`] = `
 
     // float32[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.float32Array(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -997,14 +955,13 @@ float32[] second 1`] = `
       return initOffset;
     }
 
-    #_second_offset_cache = undefined;
     second_offset(view, initOffset) {
-      if (this.#_second_offset_cache) {
-        return this.#_second_offset_cache;
+      if (this._second_offset_cache) {
+        return this._second_offset_cache;
       }
       const prevOffset = this.first_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
-      this.#_second_offset_cache = totalOffset;
+      this._second_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -1014,23 +971,21 @@ float32[] second 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._second_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -1038,16 +993,16 @@ float32[] second 1`] = `
 
     // float32[] first
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      const offset = this.first_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.float32Array(this._view, offset + 4, len);
     }
 
     // float32[] second
     get second() {
-      const offset = this.second_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      const offset = this.second_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.float32Array(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1089,23 +1044,20 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -1113,8 +1065,8 @@ exports[`LazyReader should deserialize float32[2] arr: float32[2] arr 1`] = `
 
     // float32[2] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      return deserializers.float32Array(this.#view, offset, 2);
+      const offset = this.arr_offset(this._view, this._offset);
+      return deserializers.float32Array(this._view, offset, 2);
     }
   }
   return __RootMsg;
@@ -1156,31 +1108,28 @@ exports[`LazyReader should deserialize float64 sample: float64 sample 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.float64(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.float64(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1226,31 +1175,28 @@ exports[`LazyReader should deserialize int8 STATUS_ONE = 1
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get status() {
-      const offset = this.status_offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.status_offset(this._view, this._offset);
+      return deserializers.int8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1296,14 +1242,13 @@ int8 second 1`] = `
       return initOffset;
     }
 
-    #_second_offset_cache = undefined;
     second_offset(view, initOffset) {
-      if (this.#_second_offset_cache) {
-        return this.#_second_offset_cache;
+      if (this._second_offset_cache) {
+        return this._second_offset_cache;
       }
       const prevOffset = this.first_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
-      this.#_second_offset_cache = totalOffset;
+      this._second_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -1313,35 +1258,33 @@ int8 second 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._second_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.int8(this._view, offset);
     }
     get second() {
-      const offset = this.second_offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.second_offset(this._view, this._offset);
+      return deserializers.int8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1383,31 +1326,28 @@ exports[`LazyReader should deserialize int8 sample # highest: int8 sample # high
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1449,31 +1389,28 @@ exports[`LazyReader should deserialize int8 sample # lowest: int8 sample # lowes
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1519,23 +1456,20 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -1543,9 +1477,9 @@ exports[`LazyReader should deserialize int8[] first: int8[] first 1`] = `
 
     // int8[] first
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.int8Array(this.#view, offset + 4, len);
+      const offset = this.first_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.int8Array(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1587,23 +1521,20 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -1611,8 +1542,8 @@ exports[`LazyReader should deserialize int8[4] first: int8[4] first 1`] = `
 
     // int8[4] first
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.int8Array(this.#view, offset, 4);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.int8Array(this._view, offset, 4);
     }
   }
   return __RootMsg;
@@ -1654,31 +1585,28 @@ exports[`LazyReader should deserialize int16 sample # highest: int16 sample # hi
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int16(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int16(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1720,31 +1648,28 @@ exports[`LazyReader should deserialize int16 sample # lowest: int16 sample # low
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int16(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int16(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1786,31 +1711,28 @@ exports[`LazyReader should deserialize int32 sample # highest: int32 sample # hi
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int32(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int32(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1852,31 +1774,28 @@ exports[`LazyReader should deserialize int32 sample # lowest: int32 sample # low
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int32(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int32(this._view, offset);
     }
   }
   return __RootMsg;
@@ -1922,23 +1841,20 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -1946,9 +1862,9 @@ exports[`LazyReader should deserialize int32[] arr: int32[] arr 1`] = `
 
     // int32[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.int32Array(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.int32Array(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -1990,31 +1906,28 @@ exports[`LazyReader should deserialize int64 sample # highest: int64 sample # hi
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int64(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int64(this._view, offset);
     }
   }
   return __RootMsg;
@@ -2056,31 +1969,28 @@ exports[`LazyReader should deserialize int64 sample # lowest: int64 sample # low
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.int64(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.int64(this._view, offset);
     }
   }
   return __RootMsg;
@@ -2129,14 +2039,13 @@ int8 second 1`] = `
       return initOffset;
     }
 
-    #_second_offset_cache = undefined;
     second_offset(view, initOffset) {
-      if (this.#_second_offset_cache) {
-        return this.#_second_offset_cache;
+      if (this._second_offset_cache) {
+        return this._second_offset_cache;
       }
       const prevOffset = this.first_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.first_size(view, prevOffset);
-      this.#_second_offset_cache = totalOffset;
+      this._second_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -2146,35 +2055,33 @@ int8 second 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._second_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.string(this._view, offset);
     }
     get second() {
-      const offset = this.second_offset(this.#view, this.#offset);
-      return deserializers.int8(this.#view, offset);
+      const offset = this.second_offset(this._view, this._offset);
+      return deserializers.int8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -2219,31 +2126,28 @@ exports[`LazyReader should deserialize string sample # empty string: string samp
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.string(this._view, offset);
     }
   }
   return __RootMsg;
@@ -2288,31 +2192,28 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.string(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.string(this._view, offset);
     }
   }
   return __RootMsg;
@@ -2357,23 +2258,20 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -2381,9 +2279,9 @@ exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
 
     // string[] first
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
+      const offset = this.first_offset(this._view, this._offset);
       return deserializers.dynamicArray(
-        this.#view,
+        this._view,
         offset,
         deserializers.string,
         builtinSizes.string
@@ -2432,23 +2330,20 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -2456,9 +2351,9 @@ exports[`LazyReader should deserialize string[2] first: string[2] first 1`] = `
 
     // string[2] first
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
+      const offset = this.first_offset(this._view, this._offset);
       return deserializers.fixedArray(
-        this.#view,
+        this._view,
         offset,
         2,
         deserializers.string,
@@ -2505,31 +2400,28 @@ exports[`LazyReader should deserialize time stamp: time stamp 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get stamp() {
-      const offset = this.stamp_offset(this.#view, this.#offset);
-      return deserializers.time(this.#view, offset);
+      const offset = this.stamp_offset(this._view, this._offset);
+      return deserializers.time(this._view, offset);
     }
   }
   return __RootMsg;
@@ -2575,23 +2467,20 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -2599,9 +2488,9 @@ exports[`LazyReader should deserialize time[] arr: time[] arr 1`] = `
 
     // time[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.timeArray(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.timeArray(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2643,23 +2532,20 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -2667,8 +2553,8 @@ exports[`LazyReader should deserialize time[1] arr: time[1] arr 1`] = `
 
     // time[1] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      return deserializers.timeArray(this.#view, offset, 1);
+      const offset = this.arr_offset(this._view, this._offset);
+      return deserializers.timeArray(this._view, offset, 1);
     }
   }
   return __RootMsg;
@@ -2718,14 +2604,13 @@ float32[] arr 1`] = `
       return initOffset;
     }
 
-    #_arr_offset_cache = undefined;
     arr_offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+      if (this._arr_offset_cache) {
+        return this._arr_offset_cache;
       }
       const prevOffset = this.blank_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      this._arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -2735,38 +2620,36 @@ float32[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._arr_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get blank() {
-      const offset = this.blank_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.blank_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
 
     // float32[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.float32Array(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.float32Array(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -2812,14 +2695,13 @@ float32[2] arr 1`] = `
       return initOffset;
     }
 
-    #_arr_offset_cache = undefined;
     arr_offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+      if (this._arr_offset_cache) {
+        return this._arr_offset_cache;
       }
       const prevOffset = this.blank_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      this._arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -2829,37 +2711,35 @@ float32[2] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._arr_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get blank() {
-      const offset = this.blank_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.blank_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
 
     // float32[2] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      return deserializers.float32Array(this.#view, offset, 2);
+      const offset = this.arr_offset(this._view, this._offset);
+      return deserializers.float32Array(this._view, offset, 2);
     }
   }
   return __RootMsg;
@@ -2909,14 +2789,13 @@ int32[] arr 1`] = `
       return initOffset;
     }
 
-    #_arr_offset_cache = undefined;
     arr_offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+      if (this._arr_offset_cache) {
+        return this._arr_offset_cache;
       }
       const prevOffset = this.blank_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      this._arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -2926,38 +2805,36 @@ int32[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._arr_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get blank() {
-      const offset = this.blank_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.blank_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
 
     // int32[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.int32Array(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.int32Array(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3007,14 +2884,13 @@ time[] arr 1`] = `
       return initOffset;
     }
 
-    #_arr_offset_cache = undefined;
     arr_offset(view, initOffset) {
-      if (this.#_arr_offset_cache) {
-        return this.#_arr_offset_cache;
+      if (this._arr_offset_cache) {
+        return this._arr_offset_cache;
       }
       const prevOffset = this.blank_offset(view, initOffset);
       const totalOffset = prevOffset + __RootMsg.blank_size(view, prevOffset);
-      this.#_arr_offset_cache = totalOffset;
+      this._arr_offset_cache = totalOffset;
       return totalOffset;
     }
 
@@ -3024,38 +2900,36 @@ time[] arr 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
+      this._arr_offset_cache = undefined;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get blank() {
-      const offset = this.blank_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.blank_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
 
     // time[] arr
     get arr() {
-      const offset = this.arr_offset(this.#view, this.#offset);
-      const len = this.#view.getUint32(offset, true);
-      return deserializers.timeArray(this.#view, offset + 4, len);
+      const offset = this.arr_offset(this._view, this._offset);
+      const len = this._view.getUint32(offset, true);
+      return deserializers.timeArray(this._view, offset + 4, len);
     }
   }
   return __RootMsg;
@@ -3097,31 +2971,28 @@ exports[`LazyReader should deserialize uint8 sample # highest: uint8 sample # hi
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3163,31 +3034,28 @@ exports[`LazyReader should deserialize uint8 sample # lowest: uint8 sample # low
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint8(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint8(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3229,23 +3097,20 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
@@ -3253,8 +3118,8 @@ exports[`LazyReader should deserialize uint8[4] first: uint8[4] first 1`] = `
 
     // uint8[4] first
     get first() {
-      const offset = this.first_offset(this.#view, this.#offset);
-      return deserializers.uint8Array(this.#view, offset, 4);
+      const offset = this.first_offset(this._view, this._offset);
+      return deserializers.uint8Array(this._view, offset, 4);
     }
   }
   return __RootMsg;
@@ -3296,31 +3161,28 @@ exports[`LazyReader should deserialize uint16 sample # highest: uint16 sample # 
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint16(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint16(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3362,31 +3224,28 @@ exports[`LazyReader should deserialize uint16 sample # lowest: uint16 sample # l
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint16(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint16(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3428,31 +3287,28 @@ exports[`LazyReader should deserialize uint32 sample # highest: uint32 sample # 
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint32(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint32(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3494,31 +3350,28 @@ exports[`LazyReader should deserialize uint32 sample # lowest: uint32 sample # l
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint32(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint32(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3560,31 +3413,28 @@ exports[`LazyReader should deserialize uint64 sample # highest: uint64 sample # 
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint64(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint64(this._view, offset);
     }
   }
   return __RootMsg;
@@ -3626,31 +3476,28 @@ exports[`LazyReader should deserialize uint64 sample # lowest: uint64 sample # l
       return new __RootMsg(view, offset);
     }
 
-    #view = undefined;
-    #offset;
-
     constructor(view, offset = 0) {
-      this.#view = view;
-      this.#offset = offset;
+      this._view = view;
+      this._offset = offset;
     }
 
     // return a json object of the fields
     // This fully deserializes all fields of the message into native types
     // Typed arrays are considered native types and remain as typed arrays
     toJSON() {
-      const view = this.#view;
+      const view = this._view;
       const buffer = new Uint8Array(
         view.buffer,
-        view.byteOffset + this.#offset,
-        view.byteLength - this.#offset
+        view.byteOffset + this._offset,
+        view.byteLength - this._offset
       );
       const reader = new StandardTypeReader(buffer);
       return new (typeReaders.get(\\"__RootMsg\\"))(reader);
     }
 
     get sample() {
-      const offset = this.sample_offset(this.#view, this.#offset);
-      return deserializers.uint64(this.#view, offset);
+      const offset = this.sample_offset(this._view, this._offset);
+      return deserializers.uint64(this._view, offset);
     }
   }
   return __RootMsg;


### PR DESCRIPTION
- Move class member initialization into the constructor for LazyMessageReader
- Make the Lazy vs Reg benchmarks more consistent with each other

This required changing # private fields to public (using an underscore prefix as a convention). The speedup is on the order of 1000x for class initialization in current versions of Chrome.