### PR TITLE
String lengths are unsigned

### DIFF
--- a/src/BuiltinDeserialize.ts
+++ b/src/BuiltinDeserialize.ts
@@ -163,7 +163,7 @@ export const deserializers: BuiltinReaders & {
   },
   duration: (view, offset) => deserializers.time(view, offset),
   string: (view, offset) => {
-    const len = view.getInt32(offset, true);
+    const len = view.getUint32(offset, true);
     const totalOffset = view.byteOffset + offset + 4;
     const maxLen = view.byteLength - offset;
     if (len < 0 || len > maxLen) {

--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -15,7 +15,7 @@ import messageReaderTests from "./fixtures/messageReaderTests";
 const getStringBuffer = (str: string) => {
   const data = Buffer.from(str, "utf8");
   const len = Buffer.alloc(4);
-  len.writeInt32LE(data.byteLength, 0);
+  len.writeUInt32LE(data.byteLength, 0);
   return Uint8Array.from([...len, ...data]);
 };
 

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -68,7 +68,7 @@ export class StandardTypeReader {
   }
 
   string(): string {
-    const len = this.int32();
+    const len = this.uint32();
     const totalOffset = this.view.byteOffset + this.offset;
     const maxLen = this.view.byteLength - this.offset;
     if (len < 0 || len > maxLen) {

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -14,7 +14,7 @@ import { MessageWriter } from "./MessageWriter";
 const getStringBytes = (str: string): Uint8Array => {
   const textData = new TextEncoder().encode(str);
   const output = new Uint8Array(4 + textData.length);
-  new DataView(output.buffer).setInt32(0, textData.length, true);
+  new DataView(output.buffer).setUint32(0, textData.length, true);
   output.set(textData, 4);
   return output;
 };
@@ -119,7 +119,7 @@ describe("MessageWriter", () => {
     it("writes variable length string array", () => {
       const writer = new MessageWriter(parseMessageDefinition("string[] names"));
       const buff = concat([
-        // variable length array has int32 as first entry
+        // variable length array has uint32 as first entry
         new Uint8Array([0x03, 0x00, 0x00, 0x00]),
         getStringBytes("foo"),
         getStringBytes("bar"),
@@ -156,7 +156,7 @@ describe("MessageWriter", () => {
     it("does not write any data for a zero length array", () => {
       const writer = new MessageWriter(parseMessageDefinition("string[] names"));
       const buff = concat([
-        // variable length array has int32 as first entry
+        // variable length array has uint32 as first entry
         new Uint8Array([0x00, 0x00, 0x00, 0x00]),
       ]);
 

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -44,7 +44,7 @@ class StandardTypeOffsetCalculator {
 
   // The following are used in the StandardTypeWriter.
   string(value: string): number {
-    // int32 length
+    // uint32 length
     if (typeof value !== "string") {
       throw new Error(`Expected string but got ${typeof value}`);
     }
@@ -129,7 +129,7 @@ class StandardTypeWriter {
       this.textEncoder = new TextEncoder();
     }
     const stringOffset = this.offsetCalculator.string(value);
-    this.view.setInt32(stringOffset, value.length, true);
+    this.view.setUint32(stringOffset, value.length, true);
     this.textEncoder.encodeInto(value, this.data.subarray(stringOffset + 4));
   }
 

--- a/src/buildReader.ts
+++ b/src/buildReader.ts
@@ -6,7 +6,7 @@ import { deserializers, fixedSizeTypes, FixedSizeTypes } from "./BuiltinDeserial
 const builtinSizes = {
   // strings are the only builtin type that are variable size
   string: (view: DataView, offset: number) => {
-    const len = view.getInt32(offset, true);
+    const len = view.getUint32(offset, true);
     const maxLen = view.byteLength - offset - 4;
     if (len < 0 || len > maxLen) {
       throw new RangeError(`String length error: length ${len}, maxLength ${maxLen}`);

--- a/src/fixtures/messageReaderTests.ts
+++ b/src/fixtures/messageReaderTests.ts
@@ -1,7 +1,7 @@
 const serializeString = (str: string): Uint8Array => {
   const data = Buffer.from(str, "utf8");
   const len = Buffer.alloc(4);
-  len.writeInt32LE(data.byteLength, 0);
+  len.writeUInt32LE(data.byteLength, 0);
   return Uint8Array.from([...len, ...data]);
 };
 


### PR DESCRIPTION
**Public-Facing Changes**
Fixed serialization/deserialization of strings to use uint32 instead of int32 for length prefix.


**Description**
Reference implementations:
- string https://github.com/ros/roscpp_core/blob/72ce04f8b2849e0e4587ea4d598be6ec5d24d8ca/roscpp_serialization/include/ros/serialization.h#L242
- vector https://github.com/ros/roscpp_core/blob/72ce04f8b2849e0e4587ea4d598be6ec5d24d8ca/roscpp_serialization/include/ros/serialization.h#L343