### PR TITLE
always use TextDecoder for string decoding

### DIFF
--- a/src/BuiltinDeserialize.ts
+++ b/src/BuiltinDeserialize.ts
@@ -170,12 +170,6 @@ export const deserializers: BuiltinReaders & {
       throw new RangeError(`String deserialization error: length ${len}, maxLength ${maxLen}`);
     }
     const codePoints = new Uint8Array(view.buffer, totalOffset, len);
-
-    // For short strings, using fromCharCode is faster then decoder (according to benchmarks)
-    if (codePoints.length <= 40) {
-      return String.fromCharCode.apply(null, codePoints as unknown as number[]);
-    }
-
     return decoder.decode(codePoints);
   },
   boolArray: (view, offset, len) => {

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -34,28 +34,12 @@ export class StandardTypeReader {
   buffer: ArrayBufferView;
   offset: number;
   view: DataView;
-  _decoder?: TextDecoder;
-  _decoderStatus: "NOT_INITIALIZED" | "INITIALIZED" | "NOT_AVAILABLE" = "NOT_INITIALIZED";
+  _decoder = new TextDecoder("utf8");
 
   constructor(buffer: ArrayBufferView) {
     this.buffer = buffer;
     this.offset = 0;
     this.view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
-  }
-
-  private _intializeTextDecoder() {
-    if (typeof global.TextDecoder === "undefined") {
-      this._decoderStatus = "NOT_AVAILABLE";
-      return;
-    }
-
-    try {
-      this._decoder = new global.TextDecoder("ascii");
-      this._decoderStatus = "INITIALIZED";
-    } catch (e) {
-      // Swallow the error if we don't support ascii encoding.
-      this._decoderStatus = "NOT_AVAILABLE";
-    }
   }
 
   json(): unknown {
@@ -76,26 +60,7 @@ export class StandardTypeReader {
     }
     const codePoints = new Uint8Array(this.view.buffer, totalOffset, len);
     this.offset += len;
-
-    // if the string is relatively short we can use apply, but longer strings can benefit from the speed of TextDecoder.
-    if (codePoints.length < 1000) {
-      return String.fromCharCode.apply(null, Array.from(codePoints));
-    }
-
-    // Use TextDecoder if it is available and supports the "ascii" encoding.
-    if (this._decoderStatus === "NOT_INITIALIZED") {
-      this._intializeTextDecoder();
-    }
-    if (this._decoder != undefined) {
-      return this._decoder.decode(codePoints);
-    }
-
-    // Otherwise, use string concatentation.
-    let data = "";
-    for (let i = 0; i < len; i++) {
-      data += String.fromCharCode(codePoints[i]!);
-    }
-    return data;
+    return this._decoder.decode(codePoints);
   }
 
   bool(): boolean {

--- a/src/__snapshots__/LazyMessageReader.test.ts.snap
+++ b/src/__snapshots__/LazyMessageReader.test.ts.snap
@@ -2782,6 +2782,89 @@ exports[`LazyReader should deserialize string sample # some string: string sampl
 "
 `;
 
+exports[`LazyReader should deserialize string sample: string sample 1`] = `
+"function anonymous(
+  deserializers,
+  builtinSizes,
+  typeReaders,
+  StandardTypeReader
+) {
+  class __RootMsg {
+    static sample_size(view /* dataview */, offset) {
+      return builtinSizes.string(view, offset);
+    }
+
+    // return the total serialized size of the message in the view
+    static size(view /* DataView */, initOffset = 0) {
+      let totalSize = 0;
+      let offset = initOffset;
+
+      // string sample
+      {
+        const size = __RootMsg.sample_size(view, offset);
+        totalSize += size;
+        offset += size;
+      }
+
+      return totalSize;
+    }
+
+    sample_offset(view, initOffset) {
+      return initOffset;
+    }
+
+    // return an instance of __RootMsg from the view at initOffset bytes into the view
+    // NOTE: the underlying view data lifetime must be at least the lifetime of the instance
+    static build(view /* DataView */, offset = 0) {
+      return new __RootMsg(view, offset);
+    }
+
+    #view = undefined;
+    #offset;
+
+    constructor(view, offset = 0) {
+      this.#view = view;
+      this.#offset = offset;
+    }
+
+    // return a json object of the fields
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toJSON() {
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset + this.#offset,
+        view.byteLength - this.#offset
+      );
+      const reader = new StandardTypeReader(buffer);
+      return new (typeReaders.get("__RootMsg"))(reader);
+    }
+
+    // return a plain javascript object of the message
+    // This fully deserializes all fields of the message into native types
+    // Typed arrays are considered native types and remain as typed arrays
+    toObject() {
+      const view = this.#view;
+      const buffer = new Uint8Array(
+        view.buffer,
+        view.byteOffset + this.#offset,
+        view.byteLength - this.#offset
+      );
+      const reader = new StandardTypeReader(buffer);
+      return new (typeReaders.get("__RootMsg"))(reader);
+    }
+
+    get sample() {
+      const offset = this.sample_offset(this.#view, this.#offset);
+      return deserializers.string(this.#view, offset);
+    }
+  }
+  return __RootMsg;
+}
+"
+`;
+
 exports[`LazyReader should deserialize string[] first: string[] first 1`] = `
 "function anonymous(
   deserializers,

--- a/src/fixtures/messageReaderTests.ts
+++ b/src/fixtures/messageReaderTests.ts
@@ -141,6 +141,7 @@ const messageReaderTests: MessageReaderTest[] = [
   ],
   [`string sample # empty string`, serializeString(""), { sample: "" }],
   [`string sample # some string`, serializeString("some string"), { sample: "some string" }],
+  [`string sample`, serializeString("毛地黄"), { sample: "毛地黄" }],
   [`int8[4] first`, [0x00, 0xff, 0x80, 0x7f], { first: new Int8Array([0, -1, -128, 127]) }],
   [
     `int8[] first`,


### PR DESCRIPTION
**Public-Facing Changes**
Fixed issues where utf8 decoding was not consistently used when handling handling string data.

**Description**
Resolves root cause of https://github.com/foxglove/studio/issues/4473
TextDecoder seems plenty fast nowadays: https://jsbench.me/t7l8uwwiri/1

<img width="746" alt="image" src="https://user-images.githubusercontent.com/14237/193956613-c7732a80-13bb-4921-b0d3-d67db7338022.png">
