### PR TITLE
fix encoding of non-ascii strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg-serialization",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "ROS1 (Robot Operating System) message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/src/stringLengthUtf8.test.ts
+++ b/src/stringLengthUtf8.test.ts
@@ -1,0 +1,36 @@
+import { stringLengthUtf8 } from "./stringLengthUtf8";
+
+describe("stringLengthUtf8", () => {
+  it.each([
+    "",
+    "a",
+    "ab",
+    "abc",
+    "abcd",
+    "béta",
+    "\xE9",
+    "\u0000",
+    "\u007f",
+    "\u0080",
+    "\u07ff",
+    "\u0800",
+    "\ud800", // lone high surrogate
+    "\ud800x", // lone high surrogate
+    "x\ud800", // lone high surrogate
+    "\ud800\udc00", // surrogate pair, equivalent to "𐀀" or "\u{10000}"
+    "\udbff\udfff", // surrogate pair, equivalent to "\u{10ffff}"
+    "\udc00", // lone low surrogate
+    "\udc00x", // lone low surrogate
+    "x\udc00", // lone low surrogate
+    "\u7fff",
+    "\u8000",
+    "\u8001",
+    "\uffff",
+    "\u{10000}",
+    "\u{fffff}",
+    "\u{100000}",
+    "\u{10ffff}",
+  ])("agrees with TextEncoder", (str) => {
+    expect(stringLengthUtf8(str)).toEqual(new TextEncoder().encode(str).length);
+  });
+});

--- a/src/stringLengthUtf8.ts
+++ b/src/stringLengthUtf8.ts
@@ -1,0 +1,31 @@
+/**
+ * Returns the number of bytes that would be used when encoding the string as UTF-8, effectively the
+ * same as `new TextEncoder().encode(str).length` but faster.
+ */
+export function stringLengthUtf8(str: string): number {
+  let byteLength = 0;
+  const numCodeUnits = str.length;
+  for (let i = 0; i < numCodeUnits; i++) {
+    const codeUnit = str.charCodeAt(i); // 0x0000-0xFFFF
+    if (codeUnit <= 0x7f) {
+      byteLength += 1; // 0b0xxxxxxx
+    } else if (codeUnit <= 0x7ff) {
+      byteLength += 2; // 0b110xxxxx 0b10xxxxxx
+    } else if (0xd800 <= codeUnit && codeUnit <= 0xdbff) {
+      // If the input string is valid UTF-16 then these surrogate characters come in pairs. They
+      // represent code points in the range 0x100000-0x10ffff and are represented with 4 bytes in
+      // UTF-8.
+      const nextCodeUnit = str.charCodeAt(i + 1);
+      if (0xdc00 <= nextCodeUnit && nextCodeUnit <= 0xdfff) {
+        byteLength += 4; // 0b11110xxx 0b10xxxxxx 0b10xxxxxx 0b10xxxxxx
+        i++;
+      } else {
+        byteLength += 3; // 0b1110xxxx 0b10xxxxxx 0b10xxxxxx
+      }
+    } else {
+      // <= 0xFFFF
+      byteLength += 3; // 0b1110xxxx 0b10xxxxxx 0b10xxxxxx
+    }
+  }
+  return byteLength;
+}

--- a/src/stringLengthUtf8.ts
+++ b/src/stringLengthUtf8.ts
@@ -1,6 +1,7 @@
 /**
  * Returns the number of bytes that would be used when encoding the string as UTF-8, effectively the
  * same as `new TextEncoder().encode(str).length` but faster.
+ * https://jsbench.me/nzlrkwmeiq/1
  */
 export function stringLengthUtf8(str: string): number {
   let byteLength = 0;


### PR DESCRIPTION
### Public-Facing Changes

Fixed a bug where non-ASCII strings would be truncated when `MessageWriter` encoded them as UTF-8.

### Description

Fixes #360

`str.length` is the length of the string in UTF-16. However, we use TextEncoder to encode strings as UTF-8. We could compute the length using TextEncoder itself, but this proves to be much slower than a manual calculation: https://jsbench.me/nzlrkwmeiq/1